### PR TITLE
MDEXP-49 StorageCleanupService: ability to clear up file storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.exclusions>**/ExportManagerImpl.java</sonar.exclusions>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
+    <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ComponentScan(basePackages = {
   "org.folio.dao",
+  "org.folio.service.cleanup",
   "org.folio.service.upload",
   "org.folio.service.loader",
   "org.folio.service.export",

--- a/src/main/java/org/folio/dao/FileDefinitionDao.java
+++ b/src/main/java/org/folio/dao/FileDefinitionDao.java
@@ -3,6 +3,8 @@ package org.folio.dao;
 import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.FileDefinition;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -18,6 +20,15 @@ public interface FileDefinitionDao {
    * @return future with optional {@link FileDefinition}
    */
   Future<Optional<FileDefinition>> getById(String id, String tenantId);
+
+  /**
+   * Searches for {@link FileDefinition} by status or with updatedDate greater then {@code lastUpdateDate}
+   *
+   * @param lastUpdateDate time of last fileDefinition changes
+   * @param tenantId tenant id
+   * @return future with list of {@link FileDefinition}
+   */
+  Future<List<FileDefinition>> getExpiredEntries(Date lastUpdateDate, String tenantId);
 
   /**
    * Saves {@link FileDefinition} to database
@@ -36,4 +47,13 @@ public interface FileDefinitionDao {
    * @return future with {@link FileDefinition}
    */
   Future<FileDefinition> update(FileDefinition fileDefinition, String tenantId);
+
+  /**
+   * Deletes {@link FileDefinition} from database
+   *
+   * @param id id of {@link FileDefinition} to delete
+   * @param tenantId tenant id
+   * @return future with true is succeeded
+   */
+  Future<Boolean> deleteById(String id, String tenantId);
 }

--- a/src/main/java/org/folio/dao/impl/FileDefinitionDaoImpl.java
+++ b/src/main/java/org/folio/dao/impl/FileDefinitionDaoImpl.java
@@ -60,10 +60,10 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
   }
 
   @Override
-  public Future<List<FileDefinition>> getExpiredEntries(Date lastUpdateDate, String tenantId) {
+  public Future<List<FileDefinition>> getExpiredEntries(Date expirationDate, String tenantId) {
     Promise<Results<FileDefinition>> promise = Promise.promise();
     try {
-      Criterion expiredEntriesCriterion = constructExpiredEntriesCriterion(lastUpdateDate);
+      Criterion expiredEntriesCriterion = constructExpiredEntriesCriterion(expirationDate);
       pgClientFactory.getInstance(tenantId).get(TABLE, FileDefinition.class, expiredEntriesCriterion, false, promise);
     } catch (Exception e) {
       logger.error("Error during getting fileDefinition entries by expired date", e);
@@ -108,7 +108,7 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
     return criteria;
   }
 
-  private Criterion constructExpiredEntriesCriterion(Date lastUpdateDate) {
+  private Criterion constructExpiredEntriesCriterion(Date expirationDate) {
     Criterion criterion = new Criterion();
     Criteria notEmptySourcePathCriteria = new Criteria();
     notEmptySourcePathCriteria.addField(SOURCE_PATH_FIELD)
@@ -118,7 +118,7 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
     lastUpdateDateCriteria.addField(METADATA_FIELD)
       .addField(UPDATED_DATE_FIELD)
       .setOperation(LESS_OR_EQUAL_OPERATION)
-      .setVal(lastUpdateDate.toString());
+      .setVal(expirationDate.toString());
     criterion.addCriterion(notEmptySourcePathCriteria, AND_OPERATION, lastUpdateDateCriteria);
     return criterion;
   }

--- a/src/main/java/org/folio/dao/impl/FileDefinitionDaoImpl.java
+++ b/src/main/java/org/folio/dao/impl/FileDefinitionDaoImpl.java
@@ -5,6 +5,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.UpdateResult;
+import org.apache.commons.lang3.time.TimeZones;
 import org.folio.dao.FileDefinitionDao;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.persist.Criteria.Criteria;
@@ -12,18 +13,35 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.interfaces.Results;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.TimeZone;
+
+import static org.drools.core.util.StringUtils.EMPTY;
 
 @Repository
 public class FileDefinitionDaoImpl implements FileDefinitionDao {
+  public static final String SOURCE_PATH_FIELD = "'sourcePath'";
+  public static final String NOT_EQUAL_OPERATION = "<>";
+  public static final String METADATA_FIELD = "'metadata'";
+  public static final String UPDATED_DATE_FIELD = "'updatedDate'";
+  public static final String LESS_OR_EQUAL_OPERATION = "<=";
+  public static final String AND_OPERATION = "AND";
   private final Logger logger = LoggerFactory.getLogger(FileDefinitionDaoImpl.class);
   private static final String TABLE = "file_definitions";
   private static final String ID_FIELD = "'id'";
+  private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
 
   private PostgresClientFactory pgClientFactory;
+  private SimpleDateFormat dateFormatter;
 
   public FileDefinitionDaoImpl(@Autowired PostgresClientFactory pgClientFactory) {
     this.pgClientFactory = pgClientFactory;
+    this.dateFormatter = new SimpleDateFormat(DATE_FORMAT_PATTERN);
+    this.dateFormatter.setTimeZone(TimeZone.getTimeZone(TimeZones.GMT_ID));
   }
 
   @Override
@@ -42,6 +60,19 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
   }
 
   @Override
+  public Future<List<FileDefinition>> getExpiredEntries(Date lastUpdateDate, String tenantId) {
+    Promise<Results<FileDefinition>> promise = Promise.promise();
+    try {
+      Criterion expiredEntriesCriterion = constructExpiredEntriesCriterion(lastUpdateDate);
+      pgClientFactory.getInstance(tenantId).get(TABLE, FileDefinition.class, expiredEntriesCriterion, false, promise);
+    } catch (Exception e) {
+      logger.error("Error during getting fileDefinition entries by expired date", e);
+      promise.fail(e);
+    }
+    return promise.future().map(Results::getResults);
+  }
+
+  @Override
   public Future<FileDefinition> save(FileDefinition fileDefinition, String tenantId) {
     Promise<String> promise = Promise.promise();
     pgClientFactory.getInstance(tenantId).save(TABLE, fileDefinition.getId(), fileDefinition, promise);
@@ -53,6 +84,13 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
     Promise<UpdateResult> promise = Promise.promise();
     pgClientFactory.getInstance(tenantId).update(TABLE, fileDefinition, fileDefinition.getId(), promise);
     return promise.future().map(fileDefinition);
+  }
+
+  @Override
+  public Future<Boolean> deleteById(String id, String tenantId) {
+    Promise<UpdateResult> promise = Promise.promise();
+    pgClientFactory.getInstance(tenantId).delete(TABLE, id, promise);
+    return promise.future().map(updateResult -> updateResult.getUpdated() == 1);
   }
 
   /**
@@ -69,4 +107,20 @@ public class FileDefinitionDaoImpl implements FileDefinitionDao {
     criteria.setVal(value);
     return criteria;
   }
+
+  private Criterion constructExpiredEntriesCriterion(Date lastUpdateDate) {
+    Criterion criterion = new Criterion();
+    Criteria notEmptySourcePathCriteria = new Criteria();
+    notEmptySourcePathCriteria.addField(SOURCE_PATH_FIELD)
+      .setOperation(NOT_EQUAL_OPERATION)
+      .setVal(EMPTY);
+    Criteria lastUpdateDateCriteria = new Criteria();
+    lastUpdateDateCriteria.addField(METADATA_FIELD)
+      .addField(UPDATED_DATE_FIELD)
+      .setOperation(LESS_OR_EQUAL_OPERATION)
+      .setVal(lastUpdateDate.toString());
+    criterion.addCriterion(notEmptySourcePathCriteria, AND_OPERATION, lastUpdateDateCriteria);
+    return criterion;
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -1,0 +1,62 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.service.cleanup.StorageCleanupService;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class ModTenantAPI extends TenantAPI {
+
+  private static final long DELAY_TIME_BETWEEN_CLEANUP_VALUE_MILLIS = 3600_000;
+
+  private static final Logger logger = LoggerFactory.getLogger(ModTenantAPI.class);
+
+  @Autowired
+  private StorageCleanupService storageCleanupService;
+
+  public ModTenantAPI() { //NOSONAR
+    SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
+  }
+
+  @Validate
+  @Override
+  public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers, Context context)  {
+    super.postTenant(entity, headers, asyncResult -> {
+      if (asyncResult.failed()) {
+        handlers.handle(asyncResult);
+      } else {
+        initStorageCleanupService(headers, context);
+        handlers.handle(asyncResult);
+      }
+    }, context);
+  }
+
+  private void initStorageCleanupService(Map<String, String> headers, Context context) {
+    Vertx vertx = context.owner();
+    OkapiConnectionParams params = new OkapiConnectionParams(headers);
+    vertx.setPeriodic(DELAY_TIME_BETWEEN_CLEANUP_VALUE_MILLIS, periodicHandler -> executeStorageCleanUpJob(vertx, params));
+  }
+
+  private void executeStorageCleanUpJob(Vertx vertx, OkapiConnectionParams params) {
+    vertx.<Void>executeBlocking(blockingCodeHandler -> storageCleanupService.cleanStorage(params),
+      cleanupAsyncResult -> {
+        if (cleanupAsyncResult.failed()) {
+          logger.error("Error during cleaning file storage.", cleanupAsyncResult.cause());
+        } else {
+          logger.info("File storage was successfully cleaned of unused files");
+        }
+      });
+  }
+
+}

--- a/src/main/java/org/folio/service/cleanup/StorageCleanupService.java
+++ b/src/main/java/org/folio/service/cleanup/StorageCleanupService.java
@@ -1,0 +1,15 @@
+package org.folio.service.cleanup;
+
+import io.vertx.core.Future;
+import org.folio.util.OkapiConnectionParams;
+
+public interface StorageCleanupService {
+
+  /**
+   * Cleans storage from files linked to completed fileDefinition or which have not been updated for {@code N} ms.
+   *
+   * @param params Okapi connection params
+   * @return Future with true if files were deleted and false in otherwise.
+   */
+  Future<Boolean> cleanStorage(OkapiConnectionParams params);
+}

--- a/src/main/java/org/folio/service/cleanup/StorageCleanupServiceImpl.java
+++ b/src/main/java/org/folio/service/cleanup/StorageCleanupServiceImpl.java
@@ -1,0 +1,84 @@
+package org.folio.service.cleanup;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.folio.dao.FileDefinitionDao;
+import org.folio.rest.jaxrs.model.FileDefinition;
+import org.folio.service.upload.storage.FileStorage;
+import org.folio.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StorageCleanupServiceImpl implements StorageCleanupService {
+
+  private static final long TIME_WITHOUT_CHANGES_VALUE_IN_MILLIS = 3600_000;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StorageCleanupServiceImpl.class);
+
+  @Autowired
+  private FileDefinitionDao fileDefinitionDao;
+  @Autowired
+  private FileStorage fileStorage;
+
+  @Override
+  public Future<Boolean> cleanStorage(OkapiConnectionParams params) {
+    Promise<Boolean> promise = Promise.promise();
+    return fileDefinitionDao.getExpiredEntries(getLastChangedDate(), params.getTenantId())
+      .compose(fileDefinitions -> deleteExpiredFilesAndRelatedFileDefinitions(fileDefinitions, params.getTenantId()))
+      .compose(compositeFuture -> {
+        promise.complete(isFilesDeleted(compositeFuture));
+        return promise.future();
+      });
+  }
+
+  private Date getLastChangedDate() {
+    return new Date(new Date().getTime() - TIME_WITHOUT_CHANGES_VALUE_IN_MILLIS);
+  }
+
+  private Future<CompositeFuture> deleteExpiredFilesAndRelatedFileDefinitions(List<FileDefinition> fileDefinitions, String tenantId) {
+    List<Future> deleteFilesFutures = fileDefinitions.stream()
+      .map(fileDefinition -> deleteExpiredFileAndRelatedFileDefinition(fileDefinition, tenantId))
+      .collect(Collectors.toList());
+    return CompositeFuture.all(deleteFilesFutures);
+  }
+
+  private Future<Boolean> deleteExpiredFileAndRelatedFileDefinition(FileDefinition fileDefinition, String tenantId) {
+    Promise<Boolean> promise = Promise.promise();
+    return fileStorage.deleteFileAndParentDirectory(fileDefinition)
+      .compose(isFileDeleted -> {
+        if (Boolean.TRUE.equals(isFileDeleted)) {
+          return fileDefinitionDao.deleteById(fileDefinition.getId(), tenantId);
+        }
+        return Future.succeededFuture(false);
+      })
+      .compose(isFileDefinitionDeleted -> {
+        if (Boolean.FALSE.equals(isFileDefinitionDeleted)) {
+          LOGGER.error("File definition with id {} was not deleted", fileDefinition.getId());
+        }
+        promise.complete(isFileDefinitionDeleted);
+        return promise.future();
+      });
+  }
+
+  private boolean isFilesDeleted(CompositeFuture compositeFuture) {
+    boolean isFilesDeleted = compositeFuture.<Boolean>list()
+      .stream()
+      .reduce((a, b) -> a && b)
+      .orElse(false);
+    if (isFilesDeleted) {
+      LOGGER.info("File storage cleaning has been successfully completed");
+    } else {
+      LOGGER.warn("File storage cleaning was not completed successfully");
+    }
+    return isFilesDeleted;
+  }
+
+}

--- a/src/main/java/org/folio/service/cleanup/StorageCleanupServiceImpl.java
+++ b/src/main/java/org/folio/service/cleanup/StorageCleanupServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @Service
 public class StorageCleanupServiceImpl implements StorageCleanupService {
 
-  private static final long TIME_WITHOUT_CHANGES_VALUE_IN_MILLIS = 3600_000;
+  private static final long FILE_DEFINITION_EXPIRATION_TIME_IN_MILLS = 3600_000;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StorageCleanupServiceImpl.class);
 
@@ -31,7 +31,7 @@ public class StorageCleanupServiceImpl implements StorageCleanupService {
   @Override
   public Future<Boolean> cleanStorage(OkapiConnectionParams params) {
     Promise<Boolean> promise = Promise.promise();
-    return fileDefinitionDao.getExpiredEntries(getLastChangedDate(), params.getTenantId())
+    return fileDefinitionDao.getExpiredEntries(getFileDefinitionExpirationDate(), params.getTenantId())
       .compose(fileDefinitions -> deleteExpiredFilesAndRelatedFileDefinitions(fileDefinitions, params.getTenantId()))
       .compose(compositeFuture -> {
         promise.complete(isFilesDeleted(compositeFuture));
@@ -39,8 +39,8 @@ public class StorageCleanupServiceImpl implements StorageCleanupService {
       });
   }
 
-  private Date getLastChangedDate() {
-    return new Date(new Date().getTime() - TIME_WITHOUT_CHANGES_VALUE_IN_MILLIS);
+  private Date getFileDefinitionExpirationDate() {
+    return new Date(new Date().getTime() - FILE_DEFINITION_EXPIRATION_TIME_IN_MILLS);
   }
 
   private Future<CompositeFuture> deleteExpiredFilesAndRelatedFileDefinitions(List<FileDefinition> fileDefinitions, String tenantId) {

--- a/src/main/java/org/folio/service/upload/storage/FileStorage.java
+++ b/src/main/java/org/folio/service/upload/storage/FileStorage.java
@@ -22,4 +22,9 @@ public interface FileStorage {
    * Saves file bytes to the storage and return its path
    */
   Future<FileDefinition> saveFileData(byte[] data, FileDefinition fileDefinition);
+
+  /**
+   * Deletes File and related parent directory from the storage and returns true if succeeded
+   */
+  Future<Boolean> deleteFileAndParentDirectory(FileDefinition fileDefinition);
 }

--- a/src/test/java/org/folio/rest/RestVerticleTestBase.java
+++ b/src/test/java/org/folio/rest/RestVerticleTestBase.java
@@ -29,7 +29,7 @@ public abstract class RestVerticleTestBase {
   protected static final String TENANT_ID = "diku";
   protected static final String TOKEN = "token";
   private static final String HOST = "http://localhost:";
-  private static final int PORT = NetworkUtils.nextFreePort();
+  protected static final int PORT = NetworkUtils.nextFreePort();
   protected static final String OKAPI_URL = HOST + PORT;
   protected static RequestSpecification jsonRequestSpecification;
   private static Vertx vertx;

--- a/src/test/java/org/folio/rest/RestVerticleTestBase.java
+++ b/src/test/java/org/folio/rest/RestVerticleTestBase.java
@@ -86,7 +86,7 @@ public abstract class RestVerticleTestBase {
   private void setUpOkapiConnectionParams() {
     Map<String, String> headers = new HashedMap<>();
     headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
-    headers.put(OKAPI_HEADER_URL, OKAPI_HEADER_TENANT);
+    headers.put(OKAPI_HEADER_URL, OKAPI_URL);
     this.okapiConnectionParams = new OkapiConnectionParams(headers);
   }
 

--- a/src/test/java/org/folio/rest/RestVerticleTestBase.java
+++ b/src/test/java/org/folio/rest/RestVerticleTestBase.java
@@ -8,16 +8,19 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import org.apache.commons.collections4.map.HashedMap;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.util.OkapiConnectionParams;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
@@ -30,9 +33,11 @@ public abstract class RestVerticleTestBase {
   protected static final String TOKEN = "token";
   private static final String HOST = "http://localhost:";
   protected static final int PORT = NetworkUtils.nextFreePort();
+  private static final String OKAPI_HEADER_URL = "x-okapi-url";
   protected static final String OKAPI_URL = HOST + PORT;
   protected static RequestSpecification jsonRequestSpecification;
-  private static Vertx vertx;
+  protected static Vertx vertx;
+  protected OkapiConnectionParams okapiConnectionParams;
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {
@@ -74,6 +79,18 @@ public abstract class RestVerticleTestBase {
 
   @Before
   public void setUp(TestContext context) throws IOException {
+    setUpOkapiConnectionParams();
+    setUpJsonRequestSpecification();
+  }
+
+  private void setUpOkapiConnectionParams() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
+    headers.put(OKAPI_HEADER_URL, OKAPI_HEADER_TENANT);
+    this.okapiConnectionParams = new OkapiConnectionParams(headers);
+  }
+
+  private void setUpJsonRequestSpecification() {
     this.jsonRequestSpecification = new RequestSpecBuilder()
       .setContentType(ContentType.JSON)
       .addHeader(OKAPI_HEADER_TENANT, TENANT_ID)

--- a/src/test/java/org/folio/service/ApplicationTestConfig.java
+++ b/src/test/java/org/folio/service/ApplicationTestConfig.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.service.loader",
   "org.folio.service.export",
   "org.folio.service.mapping",
+  "org.folio.service.cleanup",
+  "org.folio.service.upload.storage",
   "org.folio.clients",
   "org.folio.rest.impl"})
 public class ApplicationTestConfig {

--- a/src/test/java/org/folio/service/cleanup/StorageCleanupServiceImplTest.java
+++ b/src/test/java/org/folio/service/cleanup/StorageCleanupServiceImplTest.java
@@ -1,0 +1,333 @@
+package org.folio.service.cleanup;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.collections4.map.HashedMap;
+import org.folio.dao.FileDefinitionDao;
+import org.folio.rest.RestVerticleTestBase;
+import org.folio.rest.jaxrs.model.FileDefinition;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.service.ApplicationTestConfig;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.OkapiConnectionParams;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.Map;
+
+import static java.util.Objects.nonNull;
+import static org.drools.core.util.StringUtils.EMPTY;
+import static org.folio.rest.jaxrs.model.FileDefinition.Status.COMPLETED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(VertxUnitRunner.class)
+public class StorageCleanupServiceImplTest extends RestVerticleTestBase {
+
+  private static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final String FILE_DEFINITIONS_TABLE = "file_definitions";
+  private static final String STORAGE_PATH = "./storage";
+  private static final long ONE_HOUR_ONE_MINUTE_IN_MILLIS = 3660000;
+  private static final long FIFTY_NINE_MINUTES_IN_MILLIS = 3540000;
+  private static final String FILE_DEFINITION_ID_1 = "b28793ab-4014-4df9-bfed-0b4ccd103712";
+  private static final String FILE_DEFINITION_ID_2 = "6065483b-3130-4361-b835-2c4abbb697d2";
+  private static final String TEST_FILE_1_NAME = "marc1.mrc";
+  public static final String TEST_FILE_2_NAME = "marc2.mrc";
+
+  private static Vertx vertx = Vertx.vertx();
+
+  @Autowired
+  private FileDefinitionDao fileDefinitionDao;
+  @Autowired
+  private StorageCleanupService storageCleanupService;
+
+  private OkapiConnectionParams okapiParams;
+  private FileDefinition fileDefinition1;
+  private FileDefinition fileDefinition2;
+  private File testFile1;
+  private File testFile2;
+
+  @Before
+  public void setUp(TestContext context) throws IOException {
+    super.setUp(context);
+    clearFileDefinitionTable(context);
+    setUpSpringContext();
+    setUpOkapiParams();
+    testFile1 = new File(STORAGE_PATH + "/" + FILE_DEFINITION_ID_1 + "/" + TEST_FILE_1_NAME);
+    testFile2 = new File(STORAGE_PATH + "/" + FILE_DEFINITION_ID_2 + "/" + TEST_FILE_2_NAME);
+    fileDefinition1 = createFileDefinition(FILE_DEFINITION_ID_1, testFile1.getPath(), TEST_FILE_1_NAME);
+    fileDefinition2 = createFileDefinition(FILE_DEFINITION_ID_2, testFile2.getPath(), TEST_FILE_2_NAME);
+  }
+
+  @After
+  public void tearDownFileSystem() throws IOException {
+    removeFileAndParentDirectory(testFile1);
+    removeFileAndParentDirectory(testFile2);
+    remove(new File(STORAGE_PATH));
+  }
+
+  @Test
+  public void shouldRemoveFile_andFileDefinition_whenFileDefinitionWasUpdatedLaterThanHourAgo(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    createTestFileAndDirectories(testFile1);
+    fileDefinition1.getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertTrue(ar.result());
+        assertFalse(testFile1.exists());
+        assertFalse(Files.exists(Paths.get(testFile1.getParent())));
+        assertFileDefinitionIsRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  @Test
+  public void shouldRemoveTwoFiles_andFileDefinitions_whenFileDefinitionsWasUpdatedLaterThanHourAgo(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    createTestFileAndDirectories(testFile1);
+    fileDefinition1.getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+    createTestFileAndDirectories(testFile2);
+    fileDefinition2.getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveFileDefinition1Ar -> {
+      return fileDefinitionDao.save(fileDefinition2, TENANT_ID).compose(saveFileDefinition2Ar -> {
+        Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+        // then
+        future.setHandler(ar -> {
+          assertTrue(ar.succeeded());
+          assertTrue(ar.result());
+          assertFalse(testFile1.exists());
+          assertFalse(testFile2.exists());
+          assertFalse(Files.exists(Paths.get(testFile1.getParent())));
+          assertFalse(Files.exists(Paths.get(testFile2.getParent())));
+          assertFileDefinitionIsRemoved();
+          async.complete();
+        });
+        return Promise.promise().future();
+      });
+    });
+  }
+
+  @Test
+  public void shouldRemoveFileWithoutParentDirectory_whenParentDirectoryIsNull(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    testFile1 = new File("./" + TEST_FILE_1_NAME);
+    createTestFileAndDirectories(testFile1);
+    fileDefinition1.withSourcePath("./" + TEST_FILE_1_NAME)
+      .getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertTrue(ar.result());
+        assertFalse(testFile1.exists());
+        assertFileDefinitionIsRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  @Test
+  public void shouldRemoveFileWithoutParentDirectory_whenParentDirectoryIsNotEmpty(TestContext context) throws IOException {
+    // given
+    Async async = context.async();
+    createTestFileAndDirectories(testFile1);
+    createAnotherFileInFileDefinitionDirectory();
+    fileDefinition1.getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertTrue(ar.result());
+        assertFalse(testFile1.exists());
+        assertFileDefinitionIsRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  @Test
+  public void shouldRemoveFileDefinition_whenFileDoesNotExist_andFileDefinitionWasUpdatedLaterThanHourAgo(TestContext context) {
+    // given
+    Async async = context.async();
+    fileDefinition1.getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    //when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertTrue(ar.result());
+        assertFileDefinitionIsRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  @Test
+  public void shouldNotRemoveFileDefinition_whenSourcePathEmpty_andFileDefinitionWasUpdatedLaterThanHourAgo(TestContext context) {
+    // given
+    Async async = context.async();
+    fileDefinition1.withSourcePath(EMPTY)
+      .getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - ONE_HOUR_ONE_MINUTE_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertFalse(ar.result());
+        assertFileDefinitionIsNotRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  @Test
+  public void shouldNotRemoveFileDefinition_whenSourcePathEmpty_andFileDefinitionWasUpdatedEarlierThanHourAgo(TestContext context) {
+    // given
+    Async async = context.async();
+    fileDefinition1.withSourcePath(EMPTY)
+      .getMetadata()
+      .withUpdatedDate(new Date(new Date().getTime() - FIFTY_NINE_MINUTES_IN_MILLIS));
+
+    // when
+    fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
+      Future<Boolean> future = storageCleanupService.cleanStorage(okapiParams);
+
+      // then
+      future.setHandler(ar -> {
+        assertTrue(ar.succeeded());
+        assertFalse(ar.result());
+        assertFileDefinitionIsNotRemoved();
+        async.complete();
+      });
+      return Promise.promise().future();
+    });
+  }
+
+  private void setUpSpringContext() {
+    Context vertxContext = vertx.getOrCreateContext();
+    SpringContextUtil.init(vertxContext.owner(), vertxContext, ApplicationTestConfig.class);
+    SpringContextUtil.autowireDependencies(this, vertxContext);
+  }
+
+  private void clearFileDefinitionTable(TestContext context) {
+    Async async = context.async();
+    PostgresClient.getInstance(vertx, TENANT_ID).delete(FILE_DEFINITIONS_TABLE, new Criterion(), event -> {
+      if (event.failed()) {
+        context.fail(event.cause());
+      }
+      async.complete();
+    });
+  }
+
+  private void setUpOkapiParams() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_TENANT_HEADER, TENANT_ID);
+    headers.put(OKAPI_URL_HEADER, "http://localhost:" + PORT);
+    okapiParams = new OkapiConnectionParams(headers);
+  }
+
+  private FileDefinition createFileDefinition(String fileDefinitionId, String filePath, String fileName) {
+    return new FileDefinition()
+      .withId(fileDefinitionId)
+      .withSourcePath(filePath)
+      .withFileName(fileName)
+      .withStatus(COMPLETED)
+      .withSize(209)
+      .withMetadata(new Metadata()
+        .withCreatedDate(new Date())
+        .withUpdatedDate(new Date()));
+
+  }
+
+  private void createTestFileAndDirectories(File file) throws IOException {
+    if (!file.exists()) {
+      file.getParentFile().mkdirs();
+      file.createNewFile();
+    }
+  }
+
+  private void createAnotherFileInFileDefinitionDirectory() throws IOException {
+    testFile2 = new File(STORAGE_PATH + "/" + FILE_DEFINITION_ID_1 + "/" + TEST_FILE_2_NAME);
+    testFile2.createNewFile();
+  }
+
+  private void assertFileDefinitionIsRemoved() {
+    fileDefinitionDao.getById(FILE_DEFINITION_ID_1, TENANT_ID).setHandler(fileDefinitionAr -> {
+      assertTrue(fileDefinitionAr.failed());
+    });
+  }
+
+  private void assertFileDefinitionIsNotRemoved() {
+    fileDefinitionDao.getById(FILE_DEFINITION_ID_1, TENANT_ID).setHandler(fileDefinitionAr -> {
+      assertEquals(fileDefinitionAr.result().get(), fileDefinition1);
+    });
+  }
+
+  private void removeFileAndParentDirectory(File file) {
+    remove(file);
+    remove(file.getParentFile());
+  }
+
+  private void remove(File file) {
+    if (nonNull(file) && file.exists()) {
+      file.delete();
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
MDEXP-49 StorageCleanupService: ability to clear up file storage 
-->

## Purpose

To have the ability to remove an old files by the system automatically.
See a similar approach on the pull request

## Approach
1. Create Vertx periodic job (1 time per hour)
2. Initialize the job ModTenantAPI
3. Create interface and implementation to look up for old FileDefinitions and remove related files at the file system calling FileStorageService.deleteFile

## Acceptance criteria
1. Created StorageCleanupService
2. Covered with tests
3. Verified on reference env