### PR TITLE
Mdexp 58 - bugfix

### DIFF
--- a/src/main/java/org/folio/rest/impl/InitAPIImpl.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIImpl.java
@@ -32,16 +32,16 @@ public class InitAPIImpl implements InitAPI {
   }
 
   private void registerProxies(Context context) {
-    ExportManager exportManager = ExportManager.create(context);
+    InputDataManager inputDataManagerProxy = InputDataManager.createProxy(context.owner());
+    ExportManager exportManagerProxy = ExportManager.createProxy(context.owner());
+    context.put(InputDataManager.class.getName(), inputDataManagerProxy);
+    context.put(ExportManager.class.getName(), exportManagerProxy);
+
     new ServiceBinder(context.owner())
       .setAddress(ExportManager.EXPORT_MANAGER_ADDRESS)
-      .register(ExportManager.class, exportManager);
-    context.put(ExportManager.class.getName(), exportManager);
-
-    InputDataManager inputDataManager = InputDataManager.create(context);
+      .register(ExportManager.class,  ExportManager.create(context));
     new ServiceBinder(context.owner())
       .setAddress(InputDataManager.INPUT_DATA_MANAGER_ADDRESS)
-      .register(InputDataManager.class, inputDataManager);
-    context.put(InputDataManager.class.getName(), inputDataManager);
+      .register(InputDataManager.class,  InputDataManager.create(context));
   }
 }


### PR DESCRIPTION
Purpose
   * At this moment ExportManager and InputDataManager transfer data with each other directly, using created instances. We should enable data-transfer based on an event bus.
    https://vertx.io/docs/vertx-service-proxy/java/

Approach
  * Update InitApi: initialize(Vertx.createProxy) and use generated proxies instead of component instances