### PR TITLE
MDEXP-64: Mod-data-export release v1.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,1 +1,19 @@
-* Incremental Release Notes here.
+## 2020-13-03 v1.0.0
+
+* MDEXP-20: Project Setup
+* MDEXP-42: File upload functionality
+* MDEXP-22: SPIKE: mapping rules for inventory to MARC
+* MDEXP-34: Export inventory instance record with underlying MARC Bib record in binary MARC format
+* MDEXP-61: Create JobExecution entity
+* MDEXP-38: Implement the FileExportService
+* MDEXP-65: Create APIs GET to fetch all jobs
+* MDEXP-69: Update a jobExecution entry in DB
+* MDEXP-54: Implement the export flow
+* MDEXP-56: File Export Storage Implementation
+* MDEXP-58: Create InputDataManager 
+* MDEXP-60: POC: Saving files to S3
+* MDEXP-67: Export created file to S3
+* MDEXP-66: Create API to download MARC file from S3
+* MDEXP-2:  Save binary MARC file in the designated location
+* MDEXP-43: FileUploadService: create DAO for FileDefinition
+* MDEXP-67:	Export created file to S3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 2020-13-03 v1.0.0
 
-Export bibliographic MARC records from SRS
+Initial release, which exports MARC bibliographic records to AWS S3, for the instance UUIDs which have underlying records in SRS.
 
 * [MDEXP-69] - Update a jobExecution entry in DB
 * [MDEXP-68] - Create a S3 bucket for a tenant

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,26 @@
 ## 2020-13-03 v1.0.0
 
-* MDEXP-20: Project Setup
-* MDEXP-42: File upload functionality
-* MDEXP-22: SPIKE: mapping rules for inventory to MARC
-* MDEXP-34: Export inventory instance record with underlying MARC Bib record in binary MARC format
-* MDEXP-61: Create JobExecution entity
-* MDEXP-38: Implement the FileExportService
-* MDEXP-65: Create APIs GET to fetch all jobs
-* MDEXP-69: Update a jobExecution entry in DB
-* MDEXP-54: Implement the export flow
-* MDEXP-56: File Export Storage Implementation
-* MDEXP-58: Create InputDataManager 
-* MDEXP-60: POC: Saving files to S3
-* MDEXP-67: Export created file to S3
-* MDEXP-66: Create API to download MARC file from S3
-* MDEXP-2:  Save binary MARC file in the designated location
-* MDEXP-43: FileUploadService: create DAO for FileDefinition
-* MDEXP-67:	Export created file to S3
+Export bibliographic MARC records from SRS
+
+* [MDEXP-69] - Update a jobExecution entry in DB
+* [MDEXP-68] - Create a S3 bucket for a tenant
+* [MDEXP-67] - Export created file to S3
+* [MDEXP-66] - Create API GET /data-export/jobExecutions/{jobId}/download/{fileId}
+* [MDEXP-65] - Create APIs GET /data-export/jobExecutions to fetch all jobs
+* [MDEXP-62] - Create project for API tests
+* [MDEXP-61] - Create JobExecution entity
+* [MDEXP-60] - POC: Saving files to S3
+* [MDEXP-59] - Create PoC for the MappingProcessor
+* [MDEXP-58] - Create InputDataManager
+* [MDEXP-56] - File Export Storage Implementation
+* [MDEXP-50] - Request to include mod-data-export to be deployed on reference environments
+* [MDEXP-46] - SPIKE: Investigate saving generated export files
+* [MDEXP-30] - Java technology stack
+* [MDEXP-28] - Design Diagrams
+* [MDEXP-27] - Requirements analysis
+* [MDEXP-21] - SPIKE: evaluate the marc4j API for writer capabilities
+* [MDEXP-20] - Project Setup
+* [MDEXP-8] - Export instance records in MARC based on provided UUIDs
+* [MDEXP-6] - Create Inventory Instance to MARC Bib record mapping rules
+* [MDEXP-2] - Save binary MARC file in the designated location
+* [MDEXP-1] - SPIKE: Investigate the way to read large csv files

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>v1.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -455,7 +455,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.0.0</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
# Purpose
Release the mod-data-export

# Approach
Follow the official procedure for maven-based modules https://dev.folio.org/guidelines/release-procedures/#maven-based-modules
Also, see very helpful notes https://wiki.folio.org/display/FOLIJET/Acquisitions+-+Release+Procedures