### PR TITLE
MDEXP-74 Add file extenstion valiation to /data-export/fileDefinitions

### DIFF
--- a/src/main/java/org/folio/rest/exceptions/ServiceException.java
+++ b/src/main/java/org/folio/rest/exceptions/ServiceException.java
@@ -23,7 +23,7 @@ public class ServiceException extends RuntimeException {
     super(errCodes.getDescription());
     this.errorCode = errCodes;
     this.status = status;
-    this.message = StringUtils.EMPTY;
+    this.message = errCodes.getDescription();
   }
 
   public int getCode() {

--- a/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
@@ -113,7 +113,7 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
 
   private Future<Void> validateFileNameExtension(String fileName) {
     if (!FilenameUtils.isExtension(fileName.toLowerCase(), CSV_FORMAT_EXTENSION)) {
-      throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, "File name extension does not corresponds csv format");
+      throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, ErrorCode.INVALID_UPLOADED_FILE_EXTENSION);
     }
     return succeededFuture();
   }

--- a/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
@@ -1,19 +1,11 @@
 package org.folio.rest.impl;
 
-import static io.vertx.core.Future.succeededFuture;
-import static org.folio.rest.RestVerticle.STREAM_ABORT;
-import static org.folio.util.ExceptionToResponseMapper.map;
-import static org.folio.rest.jaxrs.model.FileDefinition.Status;
-
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import java.io.InputStream;
-import java.util.Map;
-import javax.ws.rs.core.Response;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.folio.HttpStatus;
 import org.folio.rest.annotations.Stream;
@@ -22,15 +14,25 @@ import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.resource.DataExportFileDefinitions;
 import org.folio.rest.tools.utils.TenantTool;
-import org.folio.service.file.upload.FileUploadService;
 import org.folio.service.file.definition.FileDefinitionService;
+import org.folio.service.file.upload.FileUploadService;
 import org.folio.spring.SpringContextUtil;
 import org.folio.util.ErrorCode;
 import org.folio.util.ExceptionToResponseMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.ws.rs.core.Response;
+import java.io.InputStream;
+import java.util.Map;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.RestVerticle.STREAM_ABORT;
+import static org.folio.rest.jaxrs.model.FileDefinition.Status;
+import static org.folio.util.ExceptionToResponseMapper.map;
+
 public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitions {
 
+  public static final String CSV_FORMAT_EXTENSION = "csv";
   @Autowired
   private FileDefinitionService fileDefinitionService;
 
@@ -85,19 +87,20 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
   @Override
   @Validate
   public void postDataExportFileDefinitions(FileDefinition entity, Map<String, String> okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    succeededFuture().compose(ar -> fileDefinitionService.save(entity.withStatus(Status.NEW), tenantId))
+                                            Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    succeededFuture().compose(ar -> validateFileNameExtension(entity.getFileName()))
+      .compose(ar -> fileDefinitionService.save(entity.withStatus(Status.NEW), tenantId))
       .map(PostDataExportFileDefinitionsResponse::respond201WithApplicationJson)
       .map(Response.class::cast)
       .otherwise(ExceptionToResponseMapper::map)
       .setHandler(asyncResultHandler);
- }
+  }
 
 
   @Override
   @Validate
   public void getDataExportFileDefinitionsByFileDefinitionId(String fileDefinitionId, Map<String, String> okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+                                                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     succeededFuture().compose(ar -> fileDefinitionService.getById(fileDefinitionId, tenantId))
       .map(optionalDefinition -> optionalDefinition
         .orElseThrow(() -> new ServiceException(HttpStatus.HTTP_NOT_FOUND, ErrorCode.FILE_DEFINITION_NOT_FOUND)))
@@ -106,5 +109,12 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
       .otherwise(ExceptionToResponseMapper::map)
       .setHandler(asyncResultHandler);
 
+  }
+
+  private Future<Void> validateFileNameExtension(String fileName) {
+    if (!FilenameUtils.isExtension(fileName.toLowerCase(), CSV_FORMAT_EXTENSION)) {
+      throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, "File name extension does not corresponds csv format");
+    }
+    return succeededFuture();
   }
 }

--- a/src/main/java/org/folio/util/ErrorCode.java
+++ b/src/main/java/org/folio/util/ErrorCode.java
@@ -8,7 +8,8 @@ public enum ErrorCode {
   FILE_DEFINITION_NOT_FOUND("fileDefinitionNotFound", "File Definition not found"),
   S3_BUCKET_NOT_PROVIDED("bucketNotProvided", "S3 bucket name is not found in System Properties"),
   NO_FILE_GENERATED("noFileGenerated", "Nothing to export: no binary file generated"),
-  USER_NOT_FOUND("userNotFound", "User not found");
+  USER_NOT_FOUND("userNotFound", "User not found"),
+  INVALID_UPLOADED_FILE_EXTENSION("invalidUploadedFileExtension", "File name extension does not corresponds csv format");
 
   private final String code;
   private final String description;

--- a/src/test/java/org/folio/rest/impl/FileUploadServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/FileUploadServiceTest.java
@@ -63,6 +63,24 @@ public class FileUploadServiceTest extends RestVerticleTestBase {
   }
 
   @Test
+  public void postFileDefinition_return422Status_whenFileNameExtensionNotCsv(TestContext context) {
+    Async async = context.async();
+    // given file
+    FileDefinition givenFileDefinition = new FileDefinition()
+      .withId(UUID.randomUUID().toString())
+      .withFileName("InventoryUUIDs.txt");
+    // when created a new entity
+    Response response = RestAssured.given()
+      .spec(jsonRequestSpecification)
+      .body(JsonObject.mapFrom(givenFileDefinition).encode())
+      .when()
+      .post(FILE_DEFINITION_SERVICE_URL);
+    // then retrieve it and verify
+    context.assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, response.getStatusCode());
+    async.complete();
+  }
+
+  @Test
   public void postFileDefinition_return422Status(TestContext context) {
     // given
     FileDefinition givenEntity = new FileDefinition();
@@ -131,7 +149,7 @@ public class FileUploadServiceTest extends RestVerticleTestBase {
 
     File uploadedFile = new File(uploadedFileDefinition.getSourcePath());
     assertTrue(FileUtils.contentEquals(fileToUpload, uploadedFile));
-    assertEquals(uploadedFileDefinition.getJobExecutionId(),  jobExecutions.getJobExecutions().get(0).getId());
+    assertEquals(uploadedFileDefinition.getJobExecutionId(), jobExecutions.getJobExecutions().get(0).getId());
     assertNotNull(jobExecutions.getJobExecutions().get(0).getHrId());
     // clean up storage
     FileUtils.deleteDirectory(new File("./storage"));

--- a/src/test/java/org/folio/rest/impl/FileUploadServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/FileUploadServiceTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.core.json.JsonObject;
@@ -14,6 +15,7 @@ import org.apache.http.HttpStatus;
 import org.folio.rest.RestVerticleTestBase;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobExecutionCollection;
+import org.folio.util.ErrorCode;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,23 +67,24 @@ public class FileUploadServiceTest extends RestVerticleTestBase {
   @Test
   public void postFileDefinition_return422Status_whenFileNameExtensionNotCsv(TestContext context) {
     Async async = context.async();
-    // given file
+    // given
     FileDefinition givenFileDefinition = new FileDefinition()
       .withId(UUID.randomUUID().toString())
       .withFileName("InventoryUUIDs.txt");
-    // when created a new entity
+    // when
     Response response = RestAssured.given()
       .spec(jsonRequestSpecification)
       .body(JsonObject.mapFrom(givenFileDefinition).encode())
       .when()
       .post(FILE_DEFINITION_SERVICE_URL);
-    // then retrieve it and verify
+    // then
     context.assertEquals(HttpStatus.SC_UNPROCESSABLE_ENTITY, response.getStatusCode());
+    context.assertEquals(ErrorCode.INVALID_UPLOADED_FILE_EXTENSION.getDescription(), response.getBody().asString());
     async.complete();
   }
 
   @Test
-  public void postFileDefinition_return422Status(TestContext context) {
+  public void postFileDefinition_return422Status_whenFileNameRequestParamMissing(TestContext context) {
     // given
     FileDefinition givenEntity = new FileDefinition();
     // when


### PR DESCRIPTION
## Description
Currently the validation happens on the UI but the validation should occur on the backend as well in order to prevent any malicious files being uploaded.

## Acceptance criteria

- validation only for /data-export/fileDefinitions
- Support .csv extension
- API tests are added