### PR TITLE
MDEXP-162 Fix accumulation of default rules with mapping profile transformations

### DIFF
--- a/src/main/java/org/folio/service/mapping/processor/RuleFactory.java
+++ b/src/main/java/org/folio/service/mapping/processor/RuleFactory.java
@@ -17,6 +17,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class RuleFactory {
     if (mappingProfile == null || isEmpty(mappingProfile.getTransformations())) {
       return getDefaultRules();
     }
-    List<Rule> rules = getDefaultRules();
+    List<Rule> rules = Lists.newArrayList(getDefaultRules());
     rules.addAll(buildByTransformations(mappingProfile.getTransformations()));
     return rules;
   }
@@ -63,7 +64,7 @@ public class RuleFactory {
       LOGGER.error("Failed to fetch default rules for export");
       throw new NotFoundException(e);
     }
-    this.defaultRules = Lists.newArrayList(Json.decodeValue(stringRules, Rule[].class));
+    this.defaultRules = Arrays.asList(Json.decodeValue(stringRules, Rule[].class));
     return this.defaultRules;
   }
 


### PR DESCRIPTION
## Description
Fix for the issue - rules that generated by mapping profile transformations are appended to list of default rules each time when called RuleFactory.create method with not empty mapping profile transformations. Fix includes appending default rules and transformation rules to a new list instead of appending to list of default rules

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
