### PR TITLE
MDEXP-200- adding proper schema version

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -28,7 +28,7 @@
     },
     {
       "tableName" : "job_executions",
-      "fromModuleVersion": "mod-data-export-1.1.0",
+      "fromModuleVersion": "mod-data-export-2.0.1",
       "withAuditing": false,
       "index": [{
           "fieldName" : "status",


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-200

Need to have proper fromModuleVersion for job_execution table as the foreign key constraint was added

TODO
- [ ] Set this version according to next version number that's decided