### PR TITLE
MDEXP-183 Generate MARC bib record - Instance electronic access

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -53,6 +53,10 @@
     {
       "id": "configuration",
       "version": "2.0"
+    },
+    {
+      "id": "electronic-access-relationships",
+      "version": "1.0"
     }
   ],
   "provides": [
@@ -81,6 +85,7 @@
             "inventory-storage.material-types.collection.get",
             "inventory-storage.instance-types.collection.get",
             "inventory-storage.instance-formats.collection.get",
+            "inventory-storage.electronic-access-relationships.collection.get",
             "configuration.entries.collection.get"
           ]
         },

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -3,6 +3,7 @@ package org.folio.clients;
 import static org.folio.clients.ClientUtil.buildQueryEndpoint;
 import static org.folio.clients.ClientUtil.getRequest;
 import static org.folio.util.ExternalPathResolver.CONTENT_TERMS;
+import static org.folio.util.ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS;
 import static org.folio.util.ExternalPathResolver.HOLDING;
 import static org.folio.util.ExternalPathResolver.IDENTIFIER_TYPES;
 import static org.folio.util.ExternalPathResolver.CONTRIBUTOR_NAME_TYPES;
@@ -66,6 +67,11 @@ public class InventoryClient {
   public Map<String, JsonObject> getInstanceFormats(OkapiConnectionParams params) {
     String endpoint = resourcesPathWithPrefix(INSTANCE_FORMATS) + LIMIT_PARAMETER + REFERENCE_DATA_LIMIT;
     return getReferenceDataByUrl(endpoint, params, INSTANCE_FORMATS);
+  }
+
+  public Map<String, JsonObject> getElectronicAccessRelationships(OkapiConnectionParams params) {
+    String endpoint = resourcesPathWithPrefix(ELECTRONIC_ACCESS_RELATIONSHIPS) + LIMIT_PARAMETER + REFERENCE_DATA_LIMIT;
+    return getReferenceDataByUrl(endpoint, params, ELECTRONIC_ACCESS_RELATIONSHIPS);
   }
 
   private Map<String, JsonObject> getReferenceDataByUrl(String url, OkapiConnectionParams params, String field) {

--- a/src/main/java/org/folio/service/mapping/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/service/mapping/TranslationsFunctionHolder.java
@@ -1,6 +1,7 @@
 package org.folio.service.mapping;
 
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.processor.ReferenceData;
 import org.folio.processor.rule.Metadata;
@@ -18,11 +19,14 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.CONTRIBUTOR_NAME_TYPES;
+import static org.folio.service.mapping.referencedata.ReferenceDataImpl.ELECTRONIC_ACCESS_RELATIONSHIPS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.IDENTIFIER_TYPES;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_FORMATS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_TYPES;
@@ -236,6 +240,26 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
           return StringUtils.EMPTY;
         }
       }
+    }
+  },
+
+  SET_ELECTRONIC_ACCESS_INDICATOR() {
+    @Override
+    public String apply(String value, int currentIndex, Translation translation, ReferenceData referenceData, Metadata metadata) {
+      List<String> relationshipIds = (List<String>) metadata.getData().get("relationshipId").getData();
+      if(CollectionUtils.isNotEmpty(relationshipIds)) {
+        String relationshipId = relationshipIds.get(currentIndex);
+        JsonObject relationship = referenceData.get(ELECTRONIC_ACCESS_RELATIONSHIPS).get(relationshipId);
+        if(relationship != null) {
+          String relationshipName = relationship.getString("name");
+          for(Map.Entry<String,String> parameter : translation.getParameters().entrySet()) {
+            if(relationshipName.equals(parameter.getKey())) {
+              return parameter.getValue();
+            }
+          }
+        }
+      }
+      return StringUtils.SPACE;
     }
   };
 

--- a/src/main/java/org/folio/service/mapping/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/service/mapping/TranslationsFunctionHolder.java
@@ -8,7 +8,6 @@ import org.folio.processor.rule.Metadata;
 import org.folio.processor.translations.Translation;
 import org.folio.processor.translations.TranslationFunction;
 import org.folio.processor.translations.TranslationHolder;
-import org.folio.service.mapping.referencedata.ReferenceDataImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.CONTRIBUTOR_NAME_TYPES;
@@ -247,13 +245,13 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
     @Override
     public String apply(String value, int currentIndex, Translation translation, ReferenceData referenceData, Metadata metadata) {
       List<String> relationshipIds = (List<String>) metadata.getData().get("relationshipId").getData();
-      if(CollectionUtils.isNotEmpty(relationshipIds)) {
+      if (CollectionUtils.isNotEmpty(relationshipIds)) {
         String relationshipId = relationshipIds.get(currentIndex);
         JsonObject relationship = referenceData.get(ELECTRONIC_ACCESS_RELATIONSHIPS).get(relationshipId);
-        if(relationship != null) {
+        if (relationship != null) {
           String relationshipName = relationship.getString("name");
-          for(Map.Entry<String,String> parameter : translation.getParameters().entrySet()) {
-            if(relationshipName.equals(parameter.getKey())) {
+          for (Map.Entry<String, String> parameter : translation.getParameters().entrySet()) {
+            if (relationshipName.equals(parameter.getKey())) {
               return parameter.getValue();
             }
           }

--- a/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataImpl.java
+++ b/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataImpl.java
@@ -15,6 +15,7 @@ public class ReferenceDataImpl implements ReferenceData {
   public static final String MATERIAL_TYPES = "materialTypes";
   public static final String INSTANCE_TYPES = "instanceTypes";
   public static final String INSTANCE_FORMATS = "instanceFormats";
+  public static final String ELECTRONIC_ACCESS_RELATIONSHIPS = "electronicAccessRelationships";
 
   private final Map<String, Map<String, JsonObject>> referenceDataMap = new HashMap<>();
 

--- a/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataProvider.java
+++ b/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataProvider.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.CONTRIBUTOR_NAME_TYPES;
+import static org.folio.service.mapping.referencedata.ReferenceDataImpl.ELECTRONIC_ACCESS_RELATIONSHIPS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.IDENTIFIER_TYPES;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_FORMATS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_TYPES;
@@ -50,6 +51,7 @@ public class ReferenceDataProvider {
     referenceData.put(MATERIAL_TYPES, inventoryClient.getMaterialTypes(okapiConnectionParams));
     referenceData.put(INSTANCE_TYPES, inventoryClient.getInstanceTypes(okapiConnectionParams));
     referenceData.put(INSTANCE_FORMATS, inventoryClient.getInstanceFormats(okapiConnectionParams));
+    referenceData.put(ELECTRONIC_ACCESS_RELATIONSHIPS, inventoryClient.getElectronicAccessRelationships(okapiConnectionParams));
     return referenceData;
   }
 }

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -19,6 +19,7 @@ public class ExternalPathResolver {
   public static final String MATERIAL_TYPES = "mtypes";
   public static final String INSTANCE_TYPES = "instanceTypes";
   public static final String INSTANCE_FORMATS = "instanceFormats";
+  public static final String ELECTRONIC_ACCESS_RELATIONSHIPS = "electronicAccessRelationships";
   public static final String USERS = "users";
   public static final String HOLDING = "holding";
   public static final String ITEM = "item";
@@ -43,6 +44,7 @@ public class ExternalPathResolver {
     apis.put(MATERIAL_TYPES, "/material-types");
     apis.put(INSTANCE_TYPES, "/instance-types");
     apis.put(INSTANCE_FORMATS, "/instance-formats");
+    apis.put(ELECTRONIC_ACCESS_RELATIONSHIPS, "/electronic-access-relationships");
     apis.put(USERS, "/users");
     apis.put(CONFIGURATIONS, "/configurations/entries");
 

--- a/src/main/resources/rules/rulesDefault.json
+++ b/src/main/resources/rules/rulesDefault.json
@@ -775,6 +775,51 @@
     }
   },
   {
+    "field": "865",
+    "description": "Electronic access",
+    "dataSources": [
+      {
+        "from": "$.instance.electronicAccess[*].uri",
+        "subfield": "u"
+      },
+      {
+        "from": "$.instance.electronicAccess[*].linkText",
+        "subfield": "y"
+      },
+      {
+        "from": "$.instance.electronicAccess[*].publicNote",
+        "subfield": "z"
+      },
+      {
+        "from": "$.instance.electronicAccess[*].materialsSpecification",
+        "subfield": "3"
+      },
+      {
+        "indicator": "1",
+        "translation": {
+          "function": "set_value",
+          "parameters": {
+            "value": "4"
+          }
+        }
+      },
+      {
+        "indicator": "2",
+        "translation": {
+          "function": "set_electronic_access_indicator",
+          "parameters": {
+            "Resource": "0",
+            "Version of resource": "1",
+            "Related resource": "2"
+          }
+        }
+      }
+    ],
+    "metadata": {
+      "relationshipId": "$.instance.electronicAccess[*].relationshipId"
+    }
+  },
+  {
     "field": "999",
     "description": "Unique ID of the instance record",
     "dataSources": [

--- a/src/test/java/org/folio/clients/InventoryClientUnitTest.java
+++ b/src/test/java/org/folio/clients/InventoryClientUnitTest.java
@@ -109,4 +109,15 @@ class InventoryClientUnitTest extends RestVerticleTestBase {
     Assert.assertFalse(contributorNameTypes.isEmpty());
     Assert.assertEquals(3, contributorNameTypes.size());
   }
+
+  @Test
+  void shouldRetrieveElectronicAccessRelationships() {
+    // given
+    InventoryClient inventoryClient = new InventoryClient();
+    // when
+    Map<String, JsonObject> electronicAccessRelationships = inventoryClient.getElectronicAccessRelationships(okapiConnectionParams);
+    // then
+    Assert.assertFalse(electronicAccessRelationships.isEmpty());
+    Assert.assertEquals(5, electronicAccessRelationships.size());
+  }
 }

--- a/src/test/java/org/folio/rest/MockServer.java
+++ b/src/test/java/org/folio/rest/MockServer.java
@@ -314,12 +314,12 @@ public class MockServer {
   }
 
   private void handleGetElectronicAccessRelationships(RoutingContext ctx) {
-    logger.info("handleGet ContributorName types Record got: " + ctx.request()
+    logger.info("handleGet Electronic access relationship types Record: " + ctx.request()
       .path());
     try {
-      JsonObject contributorTypes = new JsonObject(RestVerticleTestBase.getMockData(ELECTRONIC_ACCESS_RELATIONSHIPS_MOCK_DATA_PATH));
-      addServerRqRsData(HttpMethod.GET, ELECTRONIC_ACCESS_RELATIONSHIPS, contributorTypes);
-      serverResponse(ctx, 200, APPLICATION_JSON, contributorTypes.encodePrettily());
+      JsonObject electronicAccessRelationship = new JsonObject(RestVerticleTestBase.getMockData(ELECTRONIC_ACCESS_RELATIONSHIPS_MOCK_DATA_PATH));
+      addServerRqRsData(HttpMethod.GET, ELECTRONIC_ACCESS_RELATIONSHIPS, electronicAccessRelationship);
+      serverResponse(ctx, 200, APPLICATION_JSON, electronicAccessRelationship.encodePrettily());
     } catch (IOException e) {
       ctx.response()
         .setStatusCode(500)

--- a/src/test/java/org/folio/rest/MockServer.java
+++ b/src/test/java/org/folio/rest/MockServer.java
@@ -1,22 +1,5 @@
 package org.folio.rest;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.folio.util.ExternalPathResolver.CONFIGURATIONS;
-import static org.folio.util.ExternalPathResolver.CONTENT_TERMS;
-import static org.folio.util.ExternalPathResolver.IDENTIFIER_TYPES;
-import static org.folio.util.ExternalPathResolver.CONTRIBUTOR_NAME_TYPES;
-import static org.folio.util.ExternalPathResolver.INSTANCE;
-import static org.folio.util.ExternalPathResolver.INSTANCE_TYPES;
-import static org.folio.util.ExternalPathResolver.INSTANCE_FORMATS;
-import static org.folio.util.ExternalPathResolver.LOCATIONS;
-import static org.folio.util.ExternalPathResolver.MATERIAL_TYPES;
-import static org.folio.util.ExternalPathResolver.SRS;
-import static org.folio.util.ExternalPathResolver.USERS;
-import static org.folio.util.ExternalPathResolver.HOLDING;
-import static org.folio.util.ExternalPathResolver.ITEM;
-import static org.folio.util.ExternalPathResolver.resourcesPath;
-import static org.junit.Assert.fail;
-
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import com.google.common.io.Resources;
@@ -31,18 +14,35 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.folio.util.ExternalPathResolver.CONFIGURATIONS;
+import static org.folio.util.ExternalPathResolver.CONTENT_TERMS;
+import static org.folio.util.ExternalPathResolver.CONTRIBUTOR_NAME_TYPES;
+import static org.folio.util.ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS;
+import static org.folio.util.ExternalPathResolver.HOLDING;
+import static org.folio.util.ExternalPathResolver.IDENTIFIER_TYPES;
+import static org.folio.util.ExternalPathResolver.INSTANCE;
+import static org.folio.util.ExternalPathResolver.INSTANCE_FORMATS;
+import static org.folio.util.ExternalPathResolver.INSTANCE_TYPES;
+import static org.folio.util.ExternalPathResolver.ITEM;
+import static org.folio.util.ExternalPathResolver.LOCATIONS;
+import static org.folio.util.ExternalPathResolver.MATERIAL_TYPES;
+import static org.folio.util.ExternalPathResolver.SRS;
+import static org.folio.util.ExternalPathResolver.USERS;
+import static org.folio.util.ExternalPathResolver.resourcesPath;
+import static org.junit.Assert.fail;
 
 public class MockServer {
   private static final Logger logger = LoggerFactory.getLogger(MockServer.class);
@@ -64,6 +64,7 @@ public class MockServer {
   private static final String MATERIAL_TYPES_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_material_types_response.json";
   private static final String INSTANCE_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_instance_types_response.json";
   private static final String INSTANCE_FORMATS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_instance_formats_response.json";
+  private static final String ELECTRONIC_ACCESS_RELATIONSHIPS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_electronic_access_relationships_response.json";
 
   static Table<String, HttpMethod, List<JsonObject>> serverRqRs = HashBasedTable.create();
 
@@ -121,6 +122,7 @@ public class MockServer {
     router.get(resourcesPath(MATERIAL_TYPES)).handler(ctx -> handleGetMaterialTypesRecord(ctx));
     router.get(resourcesPath(INSTANCE_TYPES)).handler(ctx -> handleGetInstanceTypes(ctx));
     router.get(resourcesPath(INSTANCE_FORMATS)).handler(ctx -> handleGetInstanceFormats(ctx));
+    router.get(resourcesPath(ELECTRONIC_ACCESS_RELATIONSHIPS)).handler(ctx -> handleGetElectronicAccessRelationships(ctx));
     router.get(resourcesPath(USERS) + "/:id").handler(ctx -> handleGetUsersRecord(ctx));
     router.get(resourcesPath(HOLDING)).handler(ctx -> handleGetHoldingRecord(ctx));
     router.get(resourcesPath(ITEM)).handler(ctx -> handleGetItemRecord(ctx));
@@ -299,17 +301,31 @@ public class MockServer {
 
   private void handleGetContributorNameTypesRecord(RoutingContext ctx) {
     logger.info("handleGet ContributorName types Record got: " + ctx.request()
-    .path());
-  try {
-    JsonObject contributorTypes = new JsonObject(RestVerticleTestBase.getMockData(CONTRIBUTOR_NAME_TYPES_RECORDS_MOCK_DATA_PATH));
-    addServerRqRsData(HttpMethod.GET, CONTRIBUTOR_NAME_TYPES, contributorTypes);
-    serverResponse(ctx, 200, APPLICATION_JSON, contributorTypes.encodePrettily());
-  } catch (IOException e) {
-    ctx.response()
-      .setStatusCode(500)
-      .end();
+      .path());
+    try {
+      JsonObject contributorTypes = new JsonObject(RestVerticleTestBase.getMockData(CONTRIBUTOR_NAME_TYPES_RECORDS_MOCK_DATA_PATH));
+      addServerRqRsData(HttpMethod.GET, CONTRIBUTOR_NAME_TYPES, contributorTypes);
+      serverResponse(ctx, 200, APPLICATION_JSON, contributorTypes.encodePrettily());
+    } catch (IOException e) {
+      ctx.response()
+        .setStatusCode(500)
+        .end();
+    }
   }
-}
+
+  private void handleGetElectronicAccessRelationships(RoutingContext ctx) {
+    logger.info("handleGet ContributorName types Record got: " + ctx.request()
+      .path());
+    try {
+      JsonObject contributorTypes = new JsonObject(RestVerticleTestBase.getMockData(ELECTRONIC_ACCESS_RELATIONSHIPS_MOCK_DATA_PATH));
+      addServerRqRsData(HttpMethod.GET, ELECTRONIC_ACCESS_RELATIONSHIPS, contributorTypes);
+      serverResponse(ctx, 200, APPLICATION_JSON, contributorTypes.encodePrettily());
+    } catch (IOException e) {
+      ctx.response()
+        .setStatusCode(500)
+        .end();
+    }
+  }
 
   private void handleGetUsersRecord(RoutingContext ctx) {
     logger.info("handleGetUsersRecord got: " + ctx.request()

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -252,6 +252,7 @@ class DataExportTest extends RestVerticleTestBase {
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.MATERIAL_TYPES).size());
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_FORMATS).size());
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_TYPES).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS).size());
   }
 
   @Configuration

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -65,6 +65,7 @@ import static org.folio.TestUtil.readFileContentFromResources;
 import static org.folio.rest.jaxrs.model.RecordType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.RecordType.ITEM;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.CONTRIBUTOR_NAME_TYPES;
+import static org.folio.service.mapping.referencedata.ReferenceDataImpl.ELECTRONIC_ACCESS_RELATIONSHIPS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.IDENTIFIER_TYPES;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_FORMATS;
 import static org.folio.service.mapping.referencedata.ReferenceDataImpl.INSTANCE_TYPES;
@@ -95,6 +96,7 @@ class MappingServiceUnitTest {
     referenceData.put(MATERIAL_TYPES, getMaterialTypes());
     referenceData.put(INSTANCE_TYPES, getInstanceTypes());
     referenceData.put(INSTANCE_FORMATS, getInstanceFormats());
+    referenceData.put(ELECTRONIC_ACCESS_RELATIONSHIPS, getElectronicAccessRelationships());
   }
 
   private Map<String, JsonObject> getNatureOfContentTerms() {
@@ -179,6 +181,18 @@ class MappingServiceUnitTest {
       map.put(jsonObject.getString("id"), jsonObject);
     }
     return map;
+  }
+
+  private static Map<String, JsonObject> getElectronicAccessRelationships() {
+    Map<String, JsonObject> stringJsonObjectMap = new HashMap<>();
+    JsonArray electronicAccessRelationships =
+      new JsonObject(TestUtil.readFileContentFromResources("mockData/inventory/get_electronic_access_relationships_response.json"))
+        .getJsonArray("electronicAccessRelationships");
+    electronicAccessRelationships.stream().forEach(instanceFormat -> {
+      JsonObject jsonObject = new JsonObject(instanceFormat.toString());
+      stringJsonObjectMap.put(jsonObject.getString("id"), jsonObject);
+    });
+    return stringJsonObjectMap;
   }
 
   @Test

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -188,8 +188,8 @@ class MappingServiceUnitTest {
     JsonArray electronicAccessRelationships =
       new JsonObject(TestUtil.readFileContentFromResources("mockData/inventory/get_electronic_access_relationships_response.json"))
         .getJsonArray("electronicAccessRelationships");
-    electronicAccessRelationships.stream().forEach(instanceFormat -> {
-      JsonObject jsonObject = new JsonObject(instanceFormat.toString());
+    electronicAccessRelationships.stream().forEach(electronicAccessRelationship -> {
+      JsonObject jsonObject = new JsonObject(electronicAccessRelationship.toString());
       stringJsonObjectMap.put(jsonObject.getString("id"), jsonObject);
     });
     return stringJsonObjectMap;

--- a/src/test/java/org/folio/service/mapping/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/TranslationFunctionHolderUnitTest.java
@@ -115,8 +115,8 @@ class TranslationFunctionHolderUnitTest {
     JsonArray electronicAccessRelationships =
       new JsonObject(TestUtil.readFileContentFromResources("mockData/inventory/get_electronic_access_relationships_response.json"))
         .getJsonArray("electronicAccessRelationships");
-    electronicAccessRelationships.stream().forEach(instanceFormat -> {
-      JsonObject jsonObject = new JsonObject(instanceFormat.toString());
+    electronicAccessRelationships.stream().forEach(electronicAccessRelationship -> {
+      JsonObject jsonObject = new JsonObject(electronicAccessRelationship.toString());
       stringJsonObjectMap.put(jsonObject.getString("id"), jsonObject);
     });
     return stringJsonObjectMap;

--- a/src/test/resources/mapping/expected_marc.json
+++ b/src/test/resources/mapping/expected_marc.json
@@ -342,6 +342,86 @@
       }
     },
     {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri1"
+          },
+          {
+            "y": "linkText1"
+          },
+          {
+            "z": "publicNote1"
+          },
+          {
+            "3": "materialsSpecification1"
+          }
+        ],
+        "ind1": "4",
+        "ind2": " "
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri2"
+          },
+          {
+            "y": "linkText2"
+          },
+          {
+            "z": "publicNote2"
+          },
+          {
+            "3": "materialsSpecification2"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri3"
+          },
+          {
+            "y": "linkText3"
+          },
+          {
+            "z": "publicNote3"
+          },
+          {
+            "3": "materialsSpecification3"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "1"
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri4"
+          },
+          {
+            "y": "linkText4"
+          },
+          {
+            "z": "publicNote4"
+          },
+          {
+            "3": "materialsSpecification4"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "2"
+      }
+    },
+    {
       "999": {
         "subfields": [
           {

--- a/src/test/resources/mapping/expected_marc_record_with_holdings_and_items.json
+++ b/src/test/resources/mapping/expected_marc_record_with_holdings_and_items.json
@@ -342,6 +342,86 @@
       }
     },
     {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri1"
+          },
+          {
+            "y": "linkText1"
+          },
+          {
+            "z": "publicNote1"
+          },
+          {
+            "3": "materialsSpecification1"
+          }
+        ],
+        "ind1": "4",
+        "ind2": " "
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri2"
+          },
+          {
+            "y": "linkText2"
+          },
+          {
+            "z": "publicNote2"
+          },
+          {
+            "3": "materialsSpecification2"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "0"
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri3"
+          },
+          {
+            "y": "linkText3"
+          },
+          {
+            "z": "publicNote3"
+          },
+          {
+            "3": "materialsSpecification3"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "1"
+      }
+    },
+    {
+      "865": {
+        "subfields": [
+          {
+            "u": "/uri4"
+          },
+          {
+            "y": "linkText4"
+          },
+          {
+            "z": "publicNote4"
+          },
+          {
+            "3": "materialsSpecification4"
+          }
+        ],
+        "ind1": "4",
+        "ind2": "2"
+      }
+    },
+    {
       "900": {
         "subfields": [
           {

--- a/src/test/resources/mapping/given_inventory_instance.json
+++ b/src/test/resources/mapping/given_inventory_instance.json
@@ -154,6 +154,36 @@
       "f5e8210f-7640-459b-a71f-552567f92369",
       "485e3e1d-9f46-42b6-8c65-6bb7bd4b37f8"
     ],
+    "electronicAccess": [
+      {
+        "uri": "/uri1",
+        "linkText": "linkText1",
+        "materialsSpecification": "materialsSpecification1",
+        "publicNote": "publicNote1",
+        "relationshipId": "f50c90c9-bae0-4add-9cd0-db9092dbc9dd"
+      },
+      {
+        "uri": "/uri2",
+        "linkText": "linkText2",
+        "materialsSpecification": "materialsSpecification2",
+        "publicNote": "publicNote2",
+        "relationshipId": "f5d0068e-6272-458e-8a81-b85e7b9a14aa"
+      },
+      {
+        "uri": "/uri3",
+        "linkText": "linkText3",
+        "materialsSpecification": "materialsSpecification3",
+        "publicNote": "publicNote3",
+        "relationshipId": "3b430592-2e09-4b48-9a0c-0636d66b9fb3"
+      },
+      {
+        "uri": "/uri4",
+        "linkText": "linkText4",
+        "materialsSpecification": "materialsSpecification4",
+        "publicNote": "publicNote4",
+        "relationshipId": "5bfe1b7b-f151-4501-8cfa-23b321d5cd1e"
+      }
+    ],
     "metadata": {
       "createdDate": "2019-08-07T03:12:01.011+0000",
       "updatedDate": "2020-05-22T01:46:42.915+0000"

--- a/src/test/resources/mockData/inventory/get_electronic_access_relationships_response.json
+++ b/src/test/resources/mockData/inventory/get_electronic_access_relationships_response.json
@@ -1,0 +1,25 @@
+{
+  "electronicAccessRelationships": [
+    {
+      "id": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
+      "name": "Resource"
+    },
+    {
+      "id": "f50c90c9-bae0-4add-9cd0-db9092dbc9dd",
+      "name": "No information provided"
+    },
+    {
+      "id": "3b430592-2e09-4b48-9a0c-0636d66b9fb3",
+      "name": "Version of resource"
+    },
+    {
+      "id": "5bfe1b7b-f151-4501-8cfa-23b321d5cd1e",
+      "name": "Related resource"
+    },
+    {
+      "id": "ef03d582-219c-4221-8635-bc92f1107021",
+      "name": "No display constant generated"
+    }
+  ],
+  "totalRecords": 5
+}


### PR DESCRIPTION
## Purpose
FOLIO inventory instance contains electronic access element that will need to be mapped to the specific MARC fields while generating a record on the fly.

## Approach
Added a new rule to rulesDefault.json file with fieldId "865" and four subfields for instance electronic access fields. At the same time, this rule contains a specific data source for the second indicator. It has a translation function "set_electronic_access_indicator" and a set of parameters with electronic access relationship values and corresponding indicator values. In case if an electronic access JSON object doesn't contain relashionshipId corresponding to any of parameter key then translation function returns an empty indicator value.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.