### PR TITLE
MDEXP-253-Fix-Metadata Fix data Migration issue on goldenrod

### DIFF
--- a/src/main/resources/templates/db_scripts/default_data/create_default_job_profile.sql
+++ b/src/main/resources/templates/db_scripts/default_data/create_default_job_profile.sql
@@ -13,6 +13,14 @@ VALUES
          "lastName": "Process",
          "userName": "system_process"
        },
-       "mappingProfileId": "25d81cbe-9686-11ea-bb37-0242ac130002"
+       "mappingProfileId": "25d81cbe-9686-11ea-bb37-0242ac130002",
+       "metadata":{
+        "createdDate":"2020-07-28T00:00:00Z",
+        "createdByUserId":"00000000-0000-0000-0000-000000000000",
+        "createdByUsername":"system_process",
+        "updatedDate":"2020-07-28T00:00:00Z",
+        "updatedByUserId":"00000000-0000-0000-0000-000000000000",
+        "updatedByUsername":"system_process"
+      }
     }'
-  ) ON CONFLICT DO NOTHING;
+  ) ON CONFLICT(id) DO UPDATE SET jsonb = EXCLUDED.jsonb;

--- a/src/main/resources/templates/db_scripts/default_data/create_default_mapping_profile.sql
+++ b/src/main/resources/templates/db_scripts/default_data/create_default_mapping_profile.sql
@@ -15,6 +15,14 @@ VALUES
          "firstName": "System",
          "lastName": "Process",
          "userName": "system_process"
-       }
+       },
+       "metadata":{
+        "createdDate":"2020-07-28T00:00:00Z",
+        "createdByUserId":"00000000-0000-0000-0000-000000000000",
+        "createdByUsername":"system_process",
+        "updatedDate":"2020-07-28T00:00:00Z",
+        "updatedByUserId":"00000000-0000-0000-0000-000000000000",
+        "updatedByUsername":"system_process"
+      }
     }'
-  ) ON CONFLICT DO NOTHING;
+  ) ON CONFLICT(id) DO UPDATE SET jsonb = EXCLUDED.jsonb;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -70,12 +70,12 @@
     {
       "run": "after",
       "snippetPath": "default_data/create_default_mapping_profile.sql",
-      "fromModuleVersion": "mod-data-export-2.1.0"
+      "fromModuleVersion": "mod-data-export-2.2.0"
     },
     {
       "run": "after",
       "snippetPath": "default_data/create_default_job_profile.sql",
-      "fromModuleVersion": "mod-data-export-2.1.0"
+      "fromModuleVersion": "mod-data-export-2.2.0"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -70,12 +70,12 @@
     {
       "run": "after",
       "snippetPath": "default_data/create_default_mapping_profile.sql",
-      "fromModuleVersion": "mod-data-export-2.2.0"
+      "fromModuleVersion": "mod-data-export-2.1.4"
     },
     {
       "run": "after",
       "snippetPath": "default_data/create_default_job_profile.sql",
-      "fromModuleVersion": "mod-data-export-2.2.0"
+      "fromModuleVersion": "mod-data-export-2.1.4"
     },
     {
       "run": "after",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MDEXP-253

## Approach
After changing the mechanism of adding default profiles from API calls to DB scripts, we should add metadata to our default profiles data(previously it was created by RMB when we called our API to create profiles).

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
