### PR TITLE
MDEXP-225 Restrict deletion of default mapping profile and job profile

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataExportImplMappingProfilesImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplMappingProfilesImpl.java
@@ -61,7 +61,7 @@ public class DataExportImplMappingProfilesImpl implements DataExportMappingProfi
   @Override
   public void deleteDataExportMappingProfilesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     succeededFuture()
-      .compose(ar -> mappingProfileService.delete(id, tenantId))
+      .compose(ar -> mappingProfileService.deleteById(id, tenantId))
       .map(isDeleted -> Boolean.TRUE.equals(isDeleted)
         ? DeleteDataExportMappingProfilesByIdResponse.respond204()
         : DeleteDataExportMappingProfilesByIdResponse.respond404WithTextPlain(format("MappingProfile with id '%s' was not found", id)))

--- a/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileService.java
+++ b/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileService.java
@@ -42,7 +42,7 @@ public interface MappingProfileService {
    * @param tenantId         tenant id
    * @return future with {@link MappingProfile}
    */
-  Future<Boolean> delete(String mappingProfileId, String tenantId);
+  Future<Boolean> deleteById(String mappingProfileId, String tenantId);
 
   /**
    * Gets {@link MappingProfile}

--- a/src/test/java/org/folio/service/profiles/JobProfileServiceUnitTest.java
+++ b/src/test/java/org/folio/service/profiles/JobProfileServiceUnitTest.java
@@ -7,6 +7,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.commons.collections4.map.HashedMap;
 import org.folio.clients.UsersClient;
 import org.folio.dao.impl.JobProfileDaoImpl;
+import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.JobProfileCollection;
 import org.folio.rest.jaxrs.model.Metadata;
@@ -14,8 +15,8 @@ import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.service.profiles.jobprofile.JobProfileServiceImpl;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
@@ -46,6 +47,7 @@ class JobProfileServiceUnitTest {
   private static final String JOB_PROFILE_ID = UUID.randomUUID().toString();
   private static final String TENANT_ID = "diku";
   private static JobProfile expectedJobProfile;
+  private static String DEFAULT_JOB_PROFILE_ID = "6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a";
 
   @Spy
   @InjectMocks
@@ -119,6 +121,15 @@ class JobProfileServiceUnitTest {
   }
 
   @Test
+  void delete_shouldThrowException_ifJobProfileIsDefault(VertxTestContext context) {
+    // assert that exception is thrown
+    Assertions.assertThrows(ServiceException.class, () -> {
+      jobProfileService.deleteById(DEFAULT_JOB_PROFILE_ID, TENANT_ID);
+    });
+    context.completeNow();
+  }
+
+  @Test
   void update_shouldCallDaoUpdate(VertxTestContext context) {
     // given
     when(usersClient.getUserInfoAsync(anyString(), any(OkapiConnectionParams.class)))
@@ -132,6 +143,17 @@ class JobProfileServiceUnitTest {
       verify(jobProfileDao).update(eq(expectedJobProfile), eq(TENANT_ID));
       context.completeNow();
     }));
+  }
+
+  @Test
+  void update_shouldThrowException_ifJobProfileIsDefault(VertxTestContext context) {
+    // given
+    JobProfile defaultJobProfile = new JobProfile().withId(DEFAULT_JOB_PROFILE_ID);
+    // assert that exception is thrown
+    Assertions.assertThrows(ServiceException.class, () -> {
+      jobProfileService.update(defaultJobProfile, okapiConnectionParams);
+    });
+    context.completeNow();
   }
 
   @Test

--- a/src/test/java/org/folio/service/profiles/MappingProfileServiceUnitTest.java
+++ b/src/test/java/org/folio/service/profiles/MappingProfileServiceUnitTest.java
@@ -7,6 +7,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.commons.collections4.map.HashedMap;
 import org.folio.clients.UsersClient;
 import org.folio.dao.impl.MappingProfileDaoImpl;
+import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingProfileCollection;
 import org.folio.rest.jaxrs.model.Metadata;
@@ -16,6 +17,7 @@ import org.folio.rest.jaxrs.model.UserInfo;
 import org.folio.service.profiles.mappingprofile.MappingProfileServiceImpl;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +47,7 @@ class MappingProfileServiceUnitTest {
   private static final String MAPPING_PROFILE_ID = UUID.randomUUID().toString();
   private static final String TENANT_ID = "diku";
   private static MappingProfile expectedMappingProfile;
+  private static final String DEFAULT_MAPPING_PROFILE_ID = "25d81cbe-9686-11ea-bb37-0242ac130002";
 
   @Spy
   @InjectMocks
@@ -110,13 +113,22 @@ class MappingProfileServiceUnitTest {
     // given
     when(mappingProfileDao.delete(expectedMappingProfile.getId(), TENANT_ID)).thenReturn(succeededFuture(true));
     // when
-    Future<Boolean> future = mappingProfileService.delete(expectedMappingProfile.getId(), TENANT_ID);
+    Future<Boolean> future = mappingProfileService.deleteById(expectedMappingProfile.getId(), TENANT_ID);
     // then
     future.onComplete(ar -> context.verify(() -> {
       assertTrue(ar.succeeded());
       verify(mappingProfileDao).delete(eq(expectedMappingProfile.getId()), eq(TENANT_ID));
       context.completeNow();
     }));
+  }
+
+  @Test
+  void delete_shouldThrowException_ifMappingProfileIsDefault(VertxTestContext context) {
+    // assert that exception is thrown
+    Assertions.assertThrows(ServiceException.class, () -> {
+      mappingProfileService.deleteById(DEFAULT_MAPPING_PROFILE_ID, TENANT_ID);
+    });
+    context.completeNow();
   }
 
   @Test
@@ -133,6 +145,17 @@ class MappingProfileServiceUnitTest {
       verify(mappingProfileDao).update(eq(expectedMappingProfile), eq(TENANT_ID));
       context.completeNow();
     }));
+  }
+
+  @Test
+  void update_shouldThrowException_ifMappingProfileIsDefault(VertxTestContext context) {
+    // given
+    MappingProfile defaultMappingProfile = new MappingProfile().withId(DEFAULT_MAPPING_PROFILE_ID);
+    // assert that exception is thrown
+    Assertions.assertThrows(ServiceException.class, () -> {
+      mappingProfileService.update(defaultMappingProfile, okapiConnectionParams);
+    });
+    context.completeNow();
   }
 
   @Test


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-225

## Purpose
The purpose is to do not allow a user to delete&edit default profiles 
## Approach
Verify the id of the incoming profile, if it's default id, then throw an exception. 
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
