### PR TITLE
MDEXP-271: Adding default in display name

### DIFF
--- a/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataImpl.java
+++ b/src/main/java/org/folio/service/mapping/referencedata/ReferenceDataImpl.java
@@ -19,7 +19,7 @@ public class ReferenceDataImpl implements ReferenceData {
   public static final String ALTERNATIVE_TITLE_TYPES = "alternativeTitleTypes";
   public static final String MODES_OF_ISSUANCE = "issuanceModes";
   public static final String LOAN_TYPES = "loantypes";
-  public static final String HOLDING_NOTE_TYPES = "holdingNoteTypes";
+  public static final String HOLDING_NOTE_TYPES = "holdingsNoteTypes";
   public static final String ITEM_NOTE_TYPES = "itemNoteTypes";
 
   private final Map<String, Map<String, JsonObject>> referenceDataMap = new HashMap<>();

--- a/src/main/java/org/folio/service/transformationfields/TransformationFieldsConfig.java
+++ b/src/main/java/org/folio/service/transformationfields/TransformationFieldsConfig.java
@@ -50,7 +50,7 @@ public enum TransformationFieldsConfig {
   HOLDINGS_CALL_NUMBER_SUFFIX("callNumberSuffix", "$.holdings[*].callNumberSuffix"),
   HOLDINGS_CALL_NUMBER_TYPE("callNumberType", "$.holdings[*].callNumberTypeId"),
   HOLDING_NOTE_TYPE("holdingNoteTypeId", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && (!(@.staffOnly) || @.staffOnly == false))].note", HOLDING_NOTE_TYPES),
-  HOLDING_NOTE_TYPE_STAFF_ONLY("holdingNoteTypeId.staffOnly", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && @.staffOnly == 'true')].note", HOLDING_NOTE_TYPES),
+  HOLDING_NOTE_TYPE_STAFF_ONLY("holdingNoteTypeId.staffOnly", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && ((@.staffOnly) && @.staffOnly == true))].note", HOLDING_NOTE_TYPES),
 
   //Item specific fields
   BARCODE("barcode", "$.items[*].barcode"),
@@ -69,8 +69,8 @@ public enum TransformationFieldsConfig {
   ITEM_CALL_NUMBER_PREFIX("callNumberPrefix", "$.item[*].effectiveCallNumberComponents.prefix"),
   ITEM_CALL_NUMBER_SUFFIX("callNumberSuffix", "$.item[*].effectiveCallNumberComponents.suffix"),
   ITEM_CALL_NUMBER_TYPE("callNumberType", "$.item[*].effectiveCallNumberComponents.typeId"),
-  ITEM_NOTE_TYPE("itemNoteTypeId", "$.item[*].notes[?(@.itemNoteTypeId=='{id}' && @.staffOnly == 'false')].itemNoteTypeId", ITEM_NOTE_TYPES),
-  ITEM_NOTE_TYPE_STAFF_ONLY("itemNoteTypeId.staffOnly", "$.item[*].notes[?(@.itemNoteTypeId=='{id}' && @.staffOnly == 'true')].itemNoteTypeId", ITEM_NOTE_TYPES);
+  ITEM_NOTE_TYPE("itemNoteTypeId", "$.item[*].notes[?(@.itemNoteTypeId=='{id}' && (!(@.staffOnly) || @.staffOnly == false))].note", ITEM_NOTE_TYPES),
+  ITEM_NOTE_TYPE_STAFF_ONLY("itemNoteTypeId.staffOnly", "$.item[*].notes[?(@.itemNoteTypeId=='{id}' && ((@.staffOnly) && @.staffOnly == true))].note", ITEM_NOTE_TYPES);
 
 
   private final String fieldId;

--- a/src/main/java/org/folio/service/transformationfields/TransformationFieldsConfig.java
+++ b/src/main/java/org/folio/service/transformationfields/TransformationFieldsConfig.java
@@ -8,6 +8,9 @@ import static org.folio.service.mapping.referencedata.ReferenceDataImpl.ITEM_NOT
 
 /**
  * Initial data for the transformation field. While extending the enum, put new values in alphabetical order
+ * Few conventions to follow while creating fields:
+ * 1) default fields must have ".default" appeneded to the fieldname at the end
+ * 2) json filter that is used for comparing Strings(UUID included) must be enclosed in quotes
  */
 public enum TransformationFieldsConfig {
 
@@ -23,10 +26,10 @@ public enum TransformationFieldsConfig {
   ELECTRONIC_ACCESS_LINKTEXT("electronic.access.linkText", "$.{recordType}.electronicAccess[?(@.relationshipId=='{id}')].linkText", ELECTRONIC_ACCESS_RELATIONSHIPS),
   ELECTRONIC_ACCESS_MATERIALS_SPECIFIED("electronic.access.materialsSpecification", "$.{recordType}.electronicAccess[?(@.relationshipId=='{id}')].materialsSpecification", ELECTRONIC_ACCESS_RELATIONSHIPS),
   ELECTRONIC_ACCESS_PUBLICNOTE("electronic.access.publicNote", "$.{recordType}.electronicAccess[?(@.relationshipId=='{id}')].publicNote", ELECTRONIC_ACCESS_RELATIONSHIPS),
-  ELECTRONIC_ACCESS_URI_DEFAULT("electronic.access.uri", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri"),
-  ELECTRONIC_ACCESS_LINKTEXT_DEFAULT("electronic.access.linkText", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText"),
-  ELECTRONIC_ACCESS_MATERIALS_SPECIFIED_DEFAULT("electronic.access.materialsSpecification", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification"),
-  ELECTRONIC_ACCESS_PUBLICNOTE_DEFAULT("electronic.access.publicNote", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote"),
+  ELECTRONIC_ACCESS_URI_DEFAULT("electronic.access.uri.default", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri"),
+  ELECTRONIC_ACCESS_LINKTEXT_DEFAULT("electronic.access.linkText.default", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText"),
+  ELECTRONIC_ACCESS_MATERIALS_SPECIFIED_DEFAULT("electronic.access.materialsSpecification.default", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification"),
+  ELECTRONIC_ACCESS_PUBLICNOTE_DEFAULT("electronic.access.publicNote.default", "$.{recordType}.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote"),
 
   //Instance specific fields
   ALTERNATIVE_TITLES("alternativeTitleTypeName", "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='{id}')].name", ALTERNATIVE_TITLE_TYPES),
@@ -46,8 +49,8 @@ public enum TransformationFieldsConfig {
   HOLDINGS_CALL_NUMBER_PREFIX("callNumberPrefix", "$.holdings[*].callNumberPrefix"),
   HOLDINGS_CALL_NUMBER_SUFFIX("callNumberSuffix", "$.holdings[*].callNumberSuffix"),
   HOLDINGS_CALL_NUMBER_TYPE("callNumberType", "$.holdings[*].callNumberTypeId"),
-  HOLDING_NOTE_TYPE("holdingNoteTypeId", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && @.staffOnly == 'false')].holdingsNoteTypeId", HOLDING_NOTE_TYPES),
-  HOLDING_NOTE_TYPE_STAFF_ONLY("holdingNoteTypeId.staffOnly", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && @.staffOnly == 'true')].holdingsNoteTypeId", HOLDING_NOTE_TYPES),
+  HOLDING_NOTE_TYPE("holdingNoteTypeId", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && (!(@.staffOnly) || @.staffOnly == false))].note", HOLDING_NOTE_TYPES),
+  HOLDING_NOTE_TYPE_STAFF_ONLY("holdingNoteTypeId.staffOnly", "$.holdings[*].notes[?(@.holdingsNoteTypeId=='{id}' && @.staffOnly == 'true')].note", HOLDING_NOTE_TYPES),
 
   //Item specific fields
   BARCODE("barcode", "$.items[*].barcode"),

--- a/src/main/java/org/folio/service/transformationfields/TransformationFieldsServiceImpl.java
+++ b/src/main/java/org/folio/service/transformationfields/TransformationFieldsServiceImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.logging.log4j.util.Strings.isNotEmpty;
 import static org.folio.rest.jaxrs.model.TransformationField.RecordType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.TransformationField.RecordType.INSTANCE;
 import static org.folio.rest.jaxrs.model.TransformationField.RecordType.ITEM;

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -23,7 +23,7 @@ public class ExternalPathResolver {
   public static final String ALTERNATIVE_TITLE_TYPES = "alternativeTitleTypes";
   public static final String ISSUANCE_MODES = "issuanceModes";
   public static final String LOAN_TYPES = "loantypes";
-  public static final String HOLDING_NOTE_TYPES = "holdingNoteTypes";
+  public static final String HOLDING_NOTE_TYPES = "holdingsNoteTypes";
   public static final String ITEM_NOTE_TYPES = "itemNoteTypes";
   public static final String USERS = "users";
   public static final String HOLDING = "holding";

--- a/src/test/java/org/folio/rest/impl/TransformationFieldsServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/TransformationFieldsServiceTest.java
@@ -44,7 +44,7 @@ class TransformationFieldsServiceTest extends RestVerticleTestBase {
         .equals(TransformationField.RecordType.INSTANCE))
       .count());
 
-    assertEquals(35, transformationFieldCollection.getTransformationFields()
+    assertEquals(39, transformationFieldCollection.getTransformationFields()
       .stream()
       .filter(transformationField -> transformationField.getRecordType()
         .equals(TransformationField.RecordType.HOLDINGS))

--- a/src/test/resources/mapping/expectedTransformationFields.json
+++ b/src/test/resources/mapping/expectedTransformationFields.json
@@ -1,971 +1,971 @@
 {
-	"transformationFields": [
-		{
-			"fieldId": "holdings.callnumber",
-			"displayNameKey": "holdings.callNumber",
-			"path": "$.holdings[*].callNumber",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.callnumberprefix",
-			"displayNameKey": "holdings.callNumberPrefix",
-			"path": "$.holdings[*].callNumberPrefix",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.callnumbersuffix",
-			"displayNameKey": "holdings.callNumberSuffix",
-			"path": "$.holdings[*].callNumberSuffix",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.callnumbertype",
-			"displayNameKey": "holdings.callNumberType",
-			"path": "$.holdings[*].callNumberTypeId",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.default",
-			"displayNameKey": "holdings.electronic.access.linkText.default",
-			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.no.display.constant.generated",
-			"displayNameKey": "holdings.electronic.access.linkText",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.no.information.provided",
-			"displayNameKey": "holdings.electronic.access.linkText",
-			"referenceDataValue": "No information provided",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.related.resource",
-			"displayNameKey": "holdings.electronic.access.linkText",
-			"referenceDataValue": "Related resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.resource",
-			"displayNameKey": "holdings.electronic.access.linkText",
-			"referenceDataValue": "Resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.linktext.version.of.resource",
-			"displayNameKey": "holdings.electronic.access.linkText",
-			"referenceDataValue": "Version of resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.default",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification.default",
-			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.no.display.constant.generated",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.no.information.provided",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification",
-			"referenceDataValue": "No information provided",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.related.resource",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification",
-			"referenceDataValue": "Related resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.resource",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification",
-			"referenceDataValue": "Resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.materialsspecification.version.of.resource",
-			"displayNameKey": "holdings.electronic.access.materialsSpecification",
-			"referenceDataValue": "Version of resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.default",
-			"displayNameKey": "holdings.electronic.access.publicNote.default",
-			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.no.display.constant.generated",
-			"displayNameKey": "holdings.electronic.access.publicNote",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.no.information.provided",
-			"displayNameKey": "holdings.electronic.access.publicNote",
-			"referenceDataValue": "No information provided",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.related.resource",
-			"displayNameKey": "holdings.electronic.access.publicNote",
-			"referenceDataValue": "Related resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.resource",
-			"displayNameKey": "holdings.electronic.access.publicNote",
-			"referenceDataValue": "Resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.publicnote.version.of.resource",
-			"displayNameKey": "holdings.electronic.access.publicNote",
-			"referenceDataValue": "Version of resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.default",
-			"displayNameKey": "holdings.electronic.access.uri.default",
-			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.no.display.constant.generated",
-			"displayNameKey": "holdings.electronic.access.uri",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.no.information.provided",
-			"displayNameKey": "holdings.electronic.access.uri",
-			"referenceDataValue": "No information provided",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.related.resource",
-			"displayNameKey": "holdings.electronic.access.uri",
-			"referenceDataValue": "Related resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.resource",
-			"displayNameKey": "holdings.electronic.access.uri",
-			"referenceDataValue": "Resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.electronic.access.uri.version.of.resource",
-			"displayNameKey": "holdings.electronic.access.uri",
-			"referenceDataValue": "Version of resource",
-			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.holdingnotetypeid.copy.note",
-			"displayNameKey": "holdings.holdingNoteTypeId",
-			"referenceDataValue": "Copy note",
-			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && (!(@.staffOnly) || @.staffOnly == false))].note",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.holdingnotetypeid.electronic.bookplate",
-			"displayNameKey": "holdings.holdingNoteTypeId",
-			"referenceDataValue": "Electronic bookplate",
-			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && (!(@.staffOnly) || @.staffOnly == false))].note",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.holdingnotetypeid.staffonly.copy.note",
-			"displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
-			"referenceDataValue": "Copy note",
-			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && ((@.staffOnly) && @.staffOnly == true))].note",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.holdingnotetypeid.staffonly.electronic.bookplate",
-			"displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
-			"referenceDataValue": "Electronic bookplate",
-			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && ((@.staffOnly) && @.staffOnly == true))].note",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.hrid",
-			"displayNameKey": "holdings.hrid",
-			"path": "$.holdings.hrid",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.id",
-			"displayNameKey": "holdings.id",
-			"path": "$.holdings.id",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.instanceid",
-			"displayNameKey": "holdings.instanceId",
-			"path": "$.holdings[*].instanceId",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.metadata.createdbyuserid",
-			"displayNameKey": "holdings.metadata.createdByUserId",
-			"path": "$.holdings.metadata.createdByUserId",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.metadata.createddate",
-			"displayNameKey": "holdings.metadata.createdDate",
-			"path": "$.holdings.metadata.createdDate",
-			"recordType": "HOLDINGS",
-			"metadataParameters": {
-				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
-				"languages": "$.instance.languages"
-			}
-		},
-		{
-			"fieldId": "holdings.metadata.updatedbyuserid",
-			"displayNameKey": "holdings.metadata.updatedByUserId",
-			"path": "$.holdings.metadata.updatedByUserId",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "holdings.metadata.updateddate",
-			"displayNameKey": "holdings.metadata.updatedDate",
-			"path": "$.holdings.metadata.updatedDate",
-			"recordType": "HOLDINGS"
-		},
-		{
-			"fieldId": "instance.alternativetitletypename.cover.title",
-			"displayNameKey": "instance.alternativeTitleTypeName",
-			"referenceDataValue": "Cover title",
-			"path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.alternativetitletypename.running.title",
-			"displayNameKey": "instance.alternativeTitleTypeName",
-			"referenceDataValue": "Running title",
-			"path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.corporate.name",
-			"displayNameKey": "instance.contributorName",
-			"referenceDataValue": "Corporate name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.meeting.name",
-			"displayNameKey": "instance.contributorName",
-			"referenceDataValue": "Meeting name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.personal.name",
-			"displayNameKey": "instance.contributorName",
-			"referenceDataValue": "Personal name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.primary.corporate.name",
-			"displayNameKey": "instance.contributorName.primary",
-			"referenceDataValue": "Corporate name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.primary.meeting.name",
-			"displayNameKey": "instance.contributorName.primary",
-			"referenceDataValue": "Meeting name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.contributorname.primary.personal.name",
-			"displayNameKey": "instance.contributorName.primary",
-			"referenceDataValue": "Personal name",
-			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.editions",
-			"displayNameKey": "instance.editions",
-			"path": "$.instance.editions",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.default",
-			"displayNameKey": "instance.electronic.access.linkText.default",
-			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.no.display.constant.generated",
-			"displayNameKey": "instance.electronic.access.linkText",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.no.information.provided",
-			"displayNameKey": "instance.electronic.access.linkText",
-			"referenceDataValue": "No information provided",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.related.resource",
-			"displayNameKey": "instance.electronic.access.linkText",
-			"referenceDataValue": "Related resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.resource",
-			"displayNameKey": "instance.electronic.access.linkText",
-			"referenceDataValue": "Resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.linktext.version.of.resource",
-			"displayNameKey": "instance.electronic.access.linkText",
-			"referenceDataValue": "Version of resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.default",
-			"displayNameKey": "instance.electronic.access.materialsSpecification.default",
-			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.no.display.constant.generated",
-			"displayNameKey": "instance.electronic.access.materialsSpecification",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.no.information.provided",
-			"displayNameKey": "instance.electronic.access.materialsSpecification",
-			"referenceDataValue": "No information provided",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.related.resource",
-			"displayNameKey": "instance.electronic.access.materialsSpecification",
-			"referenceDataValue": "Related resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.resource",
-			"displayNameKey": "instance.electronic.access.materialsSpecification",
-			"referenceDataValue": "Resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.materialsspecification.version.of.resource",
-			"displayNameKey": "instance.electronic.access.materialsSpecification",
-			"referenceDataValue": "Version of resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.default",
-			"displayNameKey": "instance.electronic.access.publicNote.default",
-			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.no.display.constant.generated",
-			"displayNameKey": "instance.electronic.access.publicNote",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.no.information.provided",
-			"displayNameKey": "instance.electronic.access.publicNote",
-			"referenceDataValue": "No information provided",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.related.resource",
-			"displayNameKey": "instance.electronic.access.publicNote",
-			"referenceDataValue": "Related resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.resource",
-			"displayNameKey": "instance.electronic.access.publicNote",
-			"referenceDataValue": "Resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.publicnote.version.of.resource",
-			"displayNameKey": "instance.electronic.access.publicNote",
-			"referenceDataValue": "Version of resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.default",
-			"displayNameKey": "instance.electronic.access.uri.default",
-			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.no.display.constant.generated",
-			"displayNameKey": "instance.electronic.access.uri",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.no.information.provided",
-			"displayNameKey": "instance.electronic.access.uri",
-			"referenceDataValue": "No information provided",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.related.resource",
-			"displayNameKey": "instance.electronic.access.uri",
-			"referenceDataValue": "Related resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.resource",
-			"displayNameKey": "instance.electronic.access.uri",
-			"referenceDataValue": "Resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.electronic.access.uri.version.of.resource",
-			"displayNameKey": "instance.electronic.access.uri",
-			"referenceDataValue": "Version of resource",
-			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.hrid",
-			"displayNameKey": "instance.hrid",
-			"path": "$.instance.hrid",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.id",
-			"displayNameKey": "instance.id",
-			"path": "$.instance.id",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.gpo.item.number",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "GPO item number",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.isbn",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "ISBN",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.issn",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "ISSN",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.lccn",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "LCCN",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.oclc",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "OCLC",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.identifiers.system.control.number",
-			"displayNameKey": "instance.identifiers",
-			"referenceDataValue": "System control number",
-			"path": "$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.instancetypeid.other",
-			"displayNameKey": "instance.instanceTypeId",
-			"referenceDataValue": "other",
-			"path": "$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.instancetypeid.text",
-			"displayNameKey": "instance.instanceTypeId",
-			"referenceDataValue": "text",
-			"path": "$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.languages",
-			"displayNameKey": "instance.languages",
-			"path": "$.instance.languages",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.metadata.createdbyuserid",
-			"displayNameKey": "instance.metadata.createdByUserId",
-			"path": "$.instance.metadata.createdByUserId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.metadata.createddate",
-			"displayNameKey": "instance.metadata.createdDate",
-			"path": "$.instance.metadata.createdDate",
-			"recordType": "INSTANCE",
-			"metadataParameters": {
-				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
-				"languages": "$.instance.languages"
-			}
-		},
-		{
-			"fieldId": "instance.metadata.updatedbyuserid",
-			"displayNameKey": "instance.metadata.updatedByUserId",
-			"path": "$.instance.metadata.updatedByUserId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.metadata.updateddate",
-			"displayNameKey": "instance.metadata.updatedDate",
-			"path": "$.instance.metadata.updatedDate",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.modeofissuanceid.multipart.monograph",
-			"displayNameKey": "instance.modeOfIssuanceId",
-			"referenceDataValue": "multipart monograph",
-			"path": "$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.modeofissuanceid.single.unit",
-			"displayNameKey": "instance.modeOfIssuanceId",
-			"referenceDataValue": "single unit",
-			"path": "$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.source",
-			"displayNameKey": "instance.source",
-			"path": "$.instance.source",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.subjects",
-			"displayNameKey": "instance.subjects",
-			"path": "$.instance.subjects",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "instance.title",
-			"displayNameKey": "instance.title",
-			"path": "$.instance.title",
-			"recordType": "INSTANCE"
-		},
-		{
-			"fieldId": "item.barcode",
-			"displayNameKey": "item.barcode",
-			"path": "$.items[*].barcode",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.callnumber",
-			"displayNameKey": "item.callNumber",
-			"path": "$.item[*].effectiveCallNumberComponents.callNumber",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.callnumberprefix",
-			"displayNameKey": "item.callNumberPrefix",
-			"path": "$.item[*].effectiveCallNumberComponents.prefix",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.callnumbersuffix",
-			"displayNameKey": "item.callNumberSuffix",
-			"path": "$.item[*].effectiveCallNumberComponents.suffix",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.callnumbertype",
-			"displayNameKey": "item.callNumberType",
-			"path": "$.item[*].effectiveCallNumberComponents.typeId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.chronology",
-			"displayNameKey": "item.chronology",
-			"path": "$.items[*].chronology",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.copynumber",
-			"displayNameKey": "item.copyNumber",
-			"path": "$.items[*].copyNumber",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.descriptionofpieces",
-			"displayNameKey": "item.descriptionOfPieces",
-			"path": "$.items[*].descriptionOfPieces",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.default",
-			"displayNameKey": "item.electronic.access.linkText.default",
-			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.no.display.constant.generated",
-			"displayNameKey": "item.electronic.access.linkText",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.no.information.provided",
-			"displayNameKey": "item.electronic.access.linkText",
-			"referenceDataValue": "No information provided",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.related.resource",
-			"displayNameKey": "item.electronic.access.linkText",
-			"referenceDataValue": "Related resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.resource",
-			"displayNameKey": "item.electronic.access.linkText",
-			"referenceDataValue": "Resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.linktext.version.of.resource",
-			"displayNameKey": "item.electronic.access.linkText",
-			"referenceDataValue": "Version of resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.default",
-			"displayNameKey": "item.electronic.access.materialsSpecification.default",
-			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.no.display.constant.generated",
-			"displayNameKey": "item.electronic.access.materialsSpecification",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.no.information.provided",
-			"displayNameKey": "item.electronic.access.materialsSpecification",
-			"referenceDataValue": "No information provided",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.related.resource",
-			"displayNameKey": "item.electronic.access.materialsSpecification",
-			"referenceDataValue": "Related resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.resource",
-			"displayNameKey": "item.electronic.access.materialsSpecification",
-			"referenceDataValue": "Resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.materialsspecification.version.of.resource",
-			"displayNameKey": "item.electronic.access.materialsSpecification",
-			"referenceDataValue": "Version of resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.default",
-			"displayNameKey": "item.electronic.access.publicNote.default",
-			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.no.display.constant.generated",
-			"displayNameKey": "item.electronic.access.publicNote",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.no.information.provided",
-			"displayNameKey": "item.electronic.access.publicNote",
-			"referenceDataValue": "No information provided",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.related.resource",
-			"displayNameKey": "item.electronic.access.publicNote",
-			"referenceDataValue": "Related resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.resource",
-			"displayNameKey": "item.electronic.access.publicNote",
-			"referenceDataValue": "Resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.publicnote.version.of.resource",
-			"displayNameKey": "item.electronic.access.publicNote",
-			"referenceDataValue": "Version of resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.default",
-			"displayNameKey": "item.electronic.access.uri.default",
-			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.no.display.constant.generated",
-			"displayNameKey": "item.electronic.access.uri",
-			"referenceDataValue": "No display constant generated",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.no.information.provided",
-			"displayNameKey": "item.electronic.access.uri",
-			"referenceDataValue": "No information provided",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.related.resource",
-			"displayNameKey": "item.electronic.access.uri",
-			"referenceDataValue": "Related resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.resource",
-			"displayNameKey": "item.electronic.access.uri",
-			"referenceDataValue": "Resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.electronic.access.uri.version.of.resource",
-			"displayNameKey": "item.electronic.access.uri",
-			"referenceDataValue": "Version of resource",
-			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.enumeration",
-			"displayNameKey": "item.enumeration",
-			"path": "$.items[*].enumeration",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.holdingsrecordid",
-			"displayNameKey": "item.holdingsRecordId",
-			"path": "$.items[*].holdingsRecordId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.hrid",
-			"displayNameKey": "item.hrid",
-			"path": "$.item.hrid",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.id",
-			"displayNameKey": "item.id",
-			"path": "$.item.id",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.itemnotetypeid.action.note",
-			"displayNameKey": "item.itemNoteTypeId",
-			"referenceDataValue": "Action note",
-			"path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && (!(@.staffOnly) || @.staffOnly == false))].note",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.itemnotetypeid.binding",
-			"displayNameKey": "item.itemNoteTypeId",
-			"referenceDataValue": "Binding",
-			"path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && (!(@.staffOnly) || @.staffOnly == false))].note",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.itemnotetypeid.staffonly.action.note",
-			"displayNameKey": "item.itemNoteTypeId.staffOnly",
-			"referenceDataValue": "Action note",
-			"path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && ((@.staffOnly) && @.staffOnly == true))].note",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.itemnotetypeid.staffonly.binding",
-			"displayNameKey": "item.itemNoteTypeId.staffOnly",
-			"referenceDataValue": "Binding",
-			"path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && ((@.staffOnly) && @.staffOnly == true))].note",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.materialtypeid.book",
-			"displayNameKey": "item.materialTypeId",
-			"referenceDataValue": "book",
-			"path": "$.items[*].materialTypeId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.materialtypeid.dvd",
-			"displayNameKey": "item.materialTypeId",
-			"referenceDataValue": "dvd",
-			"path": "$.items[*].materialTypeId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.metadata.createdbyuserid",
-			"displayNameKey": "item.metadata.createdByUserId",
-			"path": "$.item.metadata.createdByUserId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.metadata.createddate",
-			"displayNameKey": "item.metadata.createdDate",
-			"path": "$.item.metadata.createdDate",
-			"recordType": "ITEM",
-			"metadataParameters": {
-				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
-				"languages": "$.instance.languages"
-			}
-		},
-		{
-			"fieldId": "item.metadata.updatedbyuserid",
-			"displayNameKey": "item.metadata.updatedByUserId",
-			"path": "$.item.metadata.updatedByUserId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.metadata.updateddate",
-			"displayNameKey": "item.metadata.updatedDate",
-			"path": "$.item.metadata.updatedDate",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.numberofpieces",
-			"displayNameKey": "item.numberOfPieces",
-			"path": "$.items[*].numberOfPieces",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.permanentloantypeid.can.circulate",
-			"displayNameKey": "item.permanentLoanTypeId",
-			"referenceDataValue": "Can circulate",
-			"path": "$.items[*].permanentLoanTypeId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.permanentloantypeid.reading.room",
-			"displayNameKey": "item.permanentLoanTypeId",
-			"referenceDataValue": "Reading room",
-			"path": "$.items[*].permanentLoanTypeId",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.status",
-			"displayNameKey": "item.status",
-			"path": "$.items[*].status.name",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.volume",
-			"displayNameKey": "item.volume",
-			"path": "$.items[*].volume",
-			"recordType": "ITEM"
-		},
-		{
-			"fieldId": "item.yearcaption",
-			"displayNameKey": "item.yearCaption",
-			"path": "$.items[*].yearCaption",
-			"recordType": "ITEM"
-		}
-	],
-	"totalRecords": 144
+   "transformationFields": [
+      {
+         "fieldId": "holdings.callnumber",
+         "displayNameKey": "holdings.callNumber",
+         "path": "$.holdings[*].callNumber",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.callnumberprefix",
+         "displayNameKey": "holdings.callNumberPrefix",
+         "path": "$.holdings[*].callNumberPrefix",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.callnumbersuffix",
+         "displayNameKey": "holdings.callNumberSuffix",
+         "path": "$.holdings[*].callNumberSuffix",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.callnumbertype",
+         "displayNameKey": "holdings.callNumberType",
+         "path": "$.holdings[*].callNumberTypeId",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.default",
+         "displayNameKey": "holdings.electronic.access.linkText.default",
+         "path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey": "holdings.electronic.access.linkText",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.no.information.provided",
+         "displayNameKey": "holdings.electronic.access.linkText",
+         "referenceDataValue": "No information provided",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.related.resource",
+         "displayNameKey": "holdings.electronic.access.linkText",
+         "referenceDataValue": "Related resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.resource",
+         "displayNameKey": "holdings.electronic.access.linkText",
+         "referenceDataValue": "Resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.linktext.version.of.resource",
+         "displayNameKey": "holdings.electronic.access.linkText",
+         "referenceDataValue": "Version of resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.default",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification.default",
+         "path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification",
+         "referenceDataValue": "No information provided",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.related.resource",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification",
+         "referenceDataValue": "Related resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.resource",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification",
+         "referenceDataValue": "Resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey": "holdings.electronic.access.materialsSpecification",
+         "referenceDataValue": "Version of resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.default",
+         "displayNameKey": "holdings.electronic.access.publicNote.default",
+         "path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey": "holdings.electronic.access.publicNote",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.no.information.provided",
+         "displayNameKey": "holdings.electronic.access.publicNote",
+         "referenceDataValue": "No information provided",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.related.resource",
+         "displayNameKey": "holdings.electronic.access.publicNote",
+         "referenceDataValue": "Related resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.resource",
+         "displayNameKey": "holdings.electronic.access.publicNote",
+         "referenceDataValue": "Resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.publicnote.version.of.resource",
+         "displayNameKey": "holdings.electronic.access.publicNote",
+         "referenceDataValue": "Version of resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.default",
+         "displayNameKey": "holdings.electronic.access.uri.default",
+         "path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey": "holdings.electronic.access.uri",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.no.information.provided",
+         "displayNameKey": "holdings.electronic.access.uri",
+         "referenceDataValue": "No information provided",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.related.resource",
+         "displayNameKey": "holdings.electronic.access.uri",
+         "referenceDataValue": "Related resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.resource",
+         "displayNameKey": "holdings.electronic.access.uri",
+         "referenceDataValue": "Resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.electronic.access.uri.version.of.resource",
+         "displayNameKey": "holdings.electronic.access.uri",
+         "referenceDataValue": "Version of resource",
+         "path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.holdingnotetypeid.copy.note",
+         "displayNameKey": "holdings.holdingNoteTypeId",
+         "referenceDataValue": "Copy note",
+         "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.holdingnotetypeid.electronic.bookplate",
+         "displayNameKey": "holdings.holdingNoteTypeId",
+         "referenceDataValue": "Electronic bookplate",
+         "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.holdingnotetypeid.staffonly.copy.note",
+         "displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
+         "referenceDataValue": "Copy note",
+         "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.holdingnotetypeid.staffonly.electronic.bookplate",
+         "displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
+         "referenceDataValue": "Electronic bookplate",
+         "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.hrid",
+         "displayNameKey": "holdings.hrid",
+         "path": "$.holdings.hrid",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.id",
+         "displayNameKey": "holdings.id",
+         "path": "$.holdings.id",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.instanceid",
+         "displayNameKey": "holdings.instanceId",
+         "path": "$.holdings[*].instanceId",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.metadata.createdbyuserid",
+         "displayNameKey": "holdings.metadata.createdByUserId",
+         "path": "$.holdings.metadata.createdByUserId",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.metadata.createddate",
+         "displayNameKey": "holdings.metadata.createdDate",
+         "path": "$.holdings.metadata.createdDate",
+         "recordType": "HOLDINGS",
+         "metadataParameters": {
+            "datesOfPublication": "$.instance.publication[*].dateOfPublication",
+            "languages": "$.instance.languages"
+         }
+      },
+      {
+         "fieldId": "holdings.metadata.updatedbyuserid",
+         "displayNameKey": "holdings.metadata.updatedByUserId",
+         "path": "$.holdings.metadata.updatedByUserId",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "holdings.metadata.updateddate",
+         "displayNameKey": "holdings.metadata.updatedDate",
+         "path": "$.holdings.metadata.updatedDate",
+         "recordType": "HOLDINGS"
+      },
+      {
+         "fieldId": "instance.alternativetitletypename.cover.title",
+         "displayNameKey": "instance.alternativeTitleTypeName",
+         "referenceDataValue": "Cover title",
+         "path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.alternativetitletypename.running.title",
+         "displayNameKey": "instance.alternativeTitleTypeName",
+         "referenceDataValue": "Running title",
+         "path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.corporate.name",
+         "displayNameKey": "instance.contributorName",
+         "referenceDataValue": "Corporate name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.meeting.name",
+         "displayNameKey": "instance.contributorName",
+         "referenceDataValue": "Meeting name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.personal.name",
+         "displayNameKey": "instance.contributorName",
+         "referenceDataValue": "Personal name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.primary.corporate.name",
+         "displayNameKey": "instance.contributorName.primary",
+         "referenceDataValue": "Corporate name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.primary.meeting.name",
+         "displayNameKey": "instance.contributorName.primary",
+         "referenceDataValue": "Meeting name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.contributorname.primary.personal.name",
+         "displayNameKey": "instance.contributorName.primary",
+         "referenceDataValue": "Personal name",
+         "path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.editions",
+         "displayNameKey": "instance.editions",
+         "path": "$.instance.editions",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.default",
+         "displayNameKey": "instance.electronic.access.linkText.default",
+         "path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey": "instance.electronic.access.linkText",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.no.information.provided",
+         "displayNameKey": "instance.electronic.access.linkText",
+         "referenceDataValue": "No information provided",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.related.resource",
+         "displayNameKey": "instance.electronic.access.linkText",
+         "referenceDataValue": "Related resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.resource",
+         "displayNameKey": "instance.electronic.access.linkText",
+         "referenceDataValue": "Resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.linktext.version.of.resource",
+         "displayNameKey": "instance.electronic.access.linkText",
+         "referenceDataValue": "Version of resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.default",
+         "displayNameKey": "instance.electronic.access.materialsSpecification.default",
+         "path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey": "instance.electronic.access.materialsSpecification",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey": "instance.electronic.access.materialsSpecification",
+         "referenceDataValue": "No information provided",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.related.resource",
+         "displayNameKey": "instance.electronic.access.materialsSpecification",
+         "referenceDataValue": "Related resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.resource",
+         "displayNameKey": "instance.electronic.access.materialsSpecification",
+         "referenceDataValue": "Resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey": "instance.electronic.access.materialsSpecification",
+         "referenceDataValue": "Version of resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.default",
+         "displayNameKey": "instance.electronic.access.publicNote.default",
+         "path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey": "instance.electronic.access.publicNote",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.no.information.provided",
+         "displayNameKey": "instance.electronic.access.publicNote",
+         "referenceDataValue": "No information provided",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.related.resource",
+         "displayNameKey": "instance.electronic.access.publicNote",
+         "referenceDataValue": "Related resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.resource",
+         "displayNameKey": "instance.electronic.access.publicNote",
+         "referenceDataValue": "Resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.publicnote.version.of.resource",
+         "displayNameKey": "instance.electronic.access.publicNote",
+         "referenceDataValue": "Version of resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.default",
+         "displayNameKey": "instance.electronic.access.uri.default",
+         "path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey": "instance.electronic.access.uri",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.no.information.provided",
+         "displayNameKey": "instance.electronic.access.uri",
+         "referenceDataValue": "No information provided",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.related.resource",
+         "displayNameKey": "instance.electronic.access.uri",
+         "referenceDataValue": "Related resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.resource",
+         "displayNameKey": "instance.electronic.access.uri",
+         "referenceDataValue": "Resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.electronic.access.uri.version.of.resource",
+         "displayNameKey": "instance.electronic.access.uri",
+         "referenceDataValue": "Version of resource",
+         "path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.hrid",
+         "displayNameKey": "instance.hrid",
+         "path": "$.instance.hrid",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.id",
+         "displayNameKey": "instance.id",
+         "path": "$.instance.id",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.gpo.item.number",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "GPO item number",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.isbn",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "ISBN",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.issn",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "ISSN",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.lccn",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "LCCN",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.oclc",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "OCLC",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.identifiers.system.control.number",
+         "displayNameKey": "instance.identifiers",
+         "referenceDataValue": "System control number",
+         "path": "$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.instancetypeid.other",
+         "displayNameKey": "instance.instanceTypeId",
+         "referenceDataValue": "other",
+         "path": "$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.instancetypeid.text",
+         "displayNameKey": "instance.instanceTypeId",
+         "referenceDataValue": "text",
+         "path": "$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.languages",
+         "displayNameKey": "instance.languages",
+         "path": "$.instance.languages",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.metadata.createdbyuserid",
+         "displayNameKey": "instance.metadata.createdByUserId",
+         "path": "$.instance.metadata.createdByUserId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.metadata.createddate",
+         "displayNameKey": "instance.metadata.createdDate",
+         "path": "$.instance.metadata.createdDate",
+         "recordType": "INSTANCE",
+         "metadataParameters": {
+            "datesOfPublication": "$.instance.publication[*].dateOfPublication",
+            "languages": "$.instance.languages"
+         }
+      },
+      {
+         "fieldId": "instance.metadata.updatedbyuserid",
+         "displayNameKey": "instance.metadata.updatedByUserId",
+         "path": "$.instance.metadata.updatedByUserId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.metadata.updateddate",
+         "displayNameKey": "instance.metadata.updatedDate",
+         "path": "$.instance.metadata.updatedDate",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.modeofissuanceid.multipart.monograph",
+         "displayNameKey": "instance.modeOfIssuanceId",
+         "referenceDataValue": "multipart monograph",
+         "path": "$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.modeofissuanceid.single.unit",
+         "displayNameKey": "instance.modeOfIssuanceId",
+         "referenceDataValue": "single unit",
+         "path": "$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.source",
+         "displayNameKey": "instance.source",
+         "path": "$.instance.source",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.subjects",
+         "displayNameKey": "instance.subjects",
+         "path": "$.instance.subjects",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "instance.title",
+         "displayNameKey": "instance.title",
+         "path": "$.instance.title",
+         "recordType": "INSTANCE"
+      },
+      {
+         "fieldId": "item.barcode",
+         "displayNameKey": "item.barcode",
+         "path": "$.items[*].barcode",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.callnumber",
+         "displayNameKey": "item.callNumber",
+         "path": "$.item[*].effectiveCallNumberComponents.callNumber",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.callnumberprefix",
+         "displayNameKey": "item.callNumberPrefix",
+         "path": "$.item[*].effectiveCallNumberComponents.prefix",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.callnumbersuffix",
+         "displayNameKey": "item.callNumberSuffix",
+         "path": "$.item[*].effectiveCallNumberComponents.suffix",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.callnumbertype",
+         "displayNameKey": "item.callNumberType",
+         "path": "$.item[*].effectiveCallNumberComponents.typeId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.chronology",
+         "displayNameKey": "item.chronology",
+         "path": "$.items[*].chronology",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.copynumber",
+         "displayNameKey": "item.copyNumber",
+         "path": "$.items[*].copyNumber",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.descriptionofpieces",
+         "displayNameKey": "item.descriptionOfPieces",
+         "path": "$.items[*].descriptionOfPieces",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.default",
+         "displayNameKey": "item.electronic.access.linkText.default",
+         "path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey": "item.electronic.access.linkText",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.no.information.provided",
+         "displayNameKey": "item.electronic.access.linkText",
+         "referenceDataValue": "No information provided",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.related.resource",
+         "displayNameKey": "item.electronic.access.linkText",
+         "referenceDataValue": "Related resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.resource",
+         "displayNameKey": "item.electronic.access.linkText",
+         "referenceDataValue": "Resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.linktext.version.of.resource",
+         "displayNameKey": "item.electronic.access.linkText",
+         "referenceDataValue": "Version of resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.default",
+         "displayNameKey": "item.electronic.access.materialsSpecification.default",
+         "path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey": "item.electronic.access.materialsSpecification",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey": "item.electronic.access.materialsSpecification",
+         "referenceDataValue": "No information provided",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.related.resource",
+         "displayNameKey": "item.electronic.access.materialsSpecification",
+         "referenceDataValue": "Related resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.resource",
+         "displayNameKey": "item.electronic.access.materialsSpecification",
+         "referenceDataValue": "Resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey": "item.electronic.access.materialsSpecification",
+         "referenceDataValue": "Version of resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.default",
+         "displayNameKey": "item.electronic.access.publicNote.default",
+         "path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey": "item.electronic.access.publicNote",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.no.information.provided",
+         "displayNameKey": "item.electronic.access.publicNote",
+         "referenceDataValue": "No information provided",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.related.resource",
+         "displayNameKey": "item.electronic.access.publicNote",
+         "referenceDataValue": "Related resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.resource",
+         "displayNameKey": "item.electronic.access.publicNote",
+         "referenceDataValue": "Resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.publicnote.version.of.resource",
+         "displayNameKey": "item.electronic.access.publicNote",
+         "referenceDataValue": "Version of resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.default",
+         "displayNameKey": "item.electronic.access.uri.default",
+         "path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey": "item.electronic.access.uri",
+         "referenceDataValue": "No display constant generated",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.no.information.provided",
+         "displayNameKey": "item.electronic.access.uri",
+         "referenceDataValue": "No information provided",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.related.resource",
+         "displayNameKey": "item.electronic.access.uri",
+         "referenceDataValue": "Related resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.resource",
+         "displayNameKey": "item.electronic.access.uri",
+         "referenceDataValue": "Resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.electronic.access.uri.version.of.resource",
+         "displayNameKey": "item.electronic.access.uri",
+         "referenceDataValue": "Version of resource",
+         "path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.enumeration",
+         "displayNameKey": "item.enumeration",
+         "path": "$.items[*].enumeration",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.holdingsrecordid",
+         "displayNameKey": "item.holdingsRecordId",
+         "path": "$.items[*].holdingsRecordId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.hrid",
+         "displayNameKey": "item.hrid",
+         "path": "$.item.hrid",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.id",
+         "displayNameKey": "item.id",
+         "path": "$.item.id",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.itemnotetypeid.action.note",
+         "displayNameKey": "item.itemNoteTypeId",
+         "referenceDataValue": "Action note",
+         "path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.itemnotetypeid.binding",
+         "displayNameKey": "item.itemNoteTypeId",
+         "referenceDataValue": "Binding",
+         "path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.itemnotetypeid.staffonly.action.note",
+         "displayNameKey": "item.itemNoteTypeId.staffOnly",
+         "referenceDataValue": "Action note",
+         "path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.itemnotetypeid.staffonly.binding",
+         "displayNameKey": "item.itemNoteTypeId.staffOnly",
+         "referenceDataValue": "Binding",
+         "path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.materialtypeid.book",
+         "displayNameKey": "item.materialTypeId",
+         "referenceDataValue": "book",
+         "path": "$.items[*].materialTypeId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.materialtypeid.dvd",
+         "displayNameKey": "item.materialTypeId",
+         "referenceDataValue": "dvd",
+         "path": "$.items[*].materialTypeId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.metadata.createdbyuserid",
+         "displayNameKey": "item.metadata.createdByUserId",
+         "path": "$.item.metadata.createdByUserId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.metadata.createddate",
+         "displayNameKey": "item.metadata.createdDate",
+         "path": "$.item.metadata.createdDate",
+         "recordType": "ITEM",
+         "metadataParameters": {
+            "datesOfPublication": "$.instance.publication[*].dateOfPublication",
+            "languages": "$.instance.languages"
+         }
+      },
+      {
+         "fieldId": "item.metadata.updatedbyuserid",
+         "displayNameKey": "item.metadata.updatedByUserId",
+         "path": "$.item.metadata.updatedByUserId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.metadata.updateddate",
+         "displayNameKey": "item.metadata.updatedDate",
+         "path": "$.item.metadata.updatedDate",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.numberofpieces",
+         "displayNameKey": "item.numberOfPieces",
+         "path": "$.items[*].numberOfPieces",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.permanentloantypeid.can.circulate",
+         "displayNameKey": "item.permanentLoanTypeId",
+         "referenceDataValue": "Can circulate",
+         "path": "$.items[*].permanentLoanTypeId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.permanentloantypeid.reading.room",
+         "displayNameKey": "item.permanentLoanTypeId",
+         "referenceDataValue": "Reading room",
+         "path": "$.items[*].permanentLoanTypeId",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.status",
+         "displayNameKey": "item.status",
+         "path": "$.items[*].status.name",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.volume",
+         "displayNameKey": "item.volume",
+         "path": "$.items[*].volume",
+         "recordType": "ITEM"
+      },
+      {
+         "fieldId": "item.yearcaption",
+         "displayNameKey": "item.yearCaption",
+         "path": "$.items[*].yearCaption",
+         "recordType": "ITEM"
+      }
+   ],
+   "totalRecords": 144
 }

--- a/src/test/resources/mapping/expectedTransformationFields.json
+++ b/src/test/resources/mapping/expectedTransformationFields.json
@@ -1,971 +1,971 @@
 {
-   "transformationFields":[
-      {
-         "fieldId":"holdings.callnumber",
-         "displayNameKey":"holdings.callNumber",
-         "path":"$.holdings[*].callNumber",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.callnumberprefix",
-         "displayNameKey":"holdings.callNumberPrefix",
-         "path":"$.holdings[*].callNumberPrefix",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.callnumbersuffix",
-         "displayNameKey":"holdings.callNumberSuffix",
-         "path":"$.holdings[*].callNumberSuffix",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.callnumbertype",
-         "displayNameKey":"holdings.callNumberType",
-         "path":"$.holdings[*].callNumberTypeId",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.default",
-         "displayNameKey":"holdings.electronic.access.linkText.default",
-         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.no.display.constant.generated",
-         "displayNameKey":"holdings.electronic.access.linkText",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.no.information.provided",
-         "displayNameKey":"holdings.electronic.access.linkText",
-         "referenceDataValue":"No information provided",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.related.resource",
-         "displayNameKey":"holdings.electronic.access.linkText",
-         "referenceDataValue":"Related resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.resource",
-         "displayNameKey":"holdings.electronic.access.linkText",
-         "referenceDataValue":"Resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.linktext.version.of.resource",
-         "displayNameKey":"holdings.electronic.access.linkText",
-         "referenceDataValue":"Version of resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.default",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification.default",
-         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.no.display.constant.generated",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.no.information.provided",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification",
-         "referenceDataValue":"No information provided",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.related.resource",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification",
-         "referenceDataValue":"Related resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.resource",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification",
-         "referenceDataValue":"Resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.materialsspecification.version.of.resource",
-         "displayNameKey":"holdings.electronic.access.materialsSpecification",
-         "referenceDataValue":"Version of resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.default",
-         "displayNameKey":"holdings.electronic.access.publicNote.default",
-         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.no.display.constant.generated",
-         "displayNameKey":"holdings.electronic.access.publicNote",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.no.information.provided",
-         "displayNameKey":"holdings.electronic.access.publicNote",
-         "referenceDataValue":"No information provided",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.related.resource",
-         "displayNameKey":"holdings.electronic.access.publicNote",
-         "referenceDataValue":"Related resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.resource",
-         "displayNameKey":"holdings.electronic.access.publicNote",
-         "referenceDataValue":"Resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.publicnote.version.of.resource",
-         "displayNameKey":"holdings.electronic.access.publicNote",
-         "referenceDataValue":"Version of resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.default",
-         "displayNameKey":"holdings.electronic.access.uri.default",
-         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.no.display.constant.generated",
-         "displayNameKey":"holdings.electronic.access.uri",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.no.information.provided",
-         "displayNameKey":"holdings.electronic.access.uri",
-         "referenceDataValue":"No information provided",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.related.resource",
-         "displayNameKey":"holdings.electronic.access.uri",
-         "referenceDataValue":"Related resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.resource",
-         "displayNameKey":"holdings.electronic.access.uri",
-         "referenceDataValue":"Resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.electronic.access.uri.version.of.resource",
-         "displayNameKey":"holdings.electronic.access.uri",
-         "referenceDataValue":"Version of resource",
-         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.holdingnotetypeid.copy.note",
-         "displayNameKey":"holdings.holdingNoteTypeId",
-         "referenceDataValue":"Copy note",
-         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && (!(@.staffOnly) || @.staffOnly == false))].note",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.holdingnotetypeid.electronic.bookplate",
-         "displayNameKey":"holdings.holdingNoteTypeId",
-         "referenceDataValue":"Electronic bookplate",
-         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && (!(@.staffOnly) || @.staffOnly == false))].note",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.holdingnotetypeid.staffonly.copy.note",
-         "displayNameKey":"holdings.holdingNoteTypeId.staffOnly",
-         "referenceDataValue":"Copy note",
-         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && ((@.staffOnly) && @.staffOnly == true))].note",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.holdingnotetypeid.staffonly.electronic.bookplate",
-         "displayNameKey":"holdings.holdingNoteTypeId.staffOnly",
-         "referenceDataValue":"Electronic bookplate",
-         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && ((@.staffOnly) && @.staffOnly == true))].note",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.hrid",
-         "displayNameKey":"holdings.hrid",
-         "path":"$.holdings.hrid",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.id",
-         "displayNameKey":"holdings.id",
-         "path":"$.holdings.id",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.instanceid",
-         "displayNameKey":"holdings.instanceId",
-         "path":"$.holdings[*].instanceId",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.metadata.createdbyuserid",
-         "displayNameKey":"holdings.metadata.createdByUserId",
-         "path":"$.holdings.metadata.createdByUserId",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.metadata.createddate",
-         "displayNameKey":"holdings.metadata.createdDate",
-         "path":"$.holdings.metadata.createdDate",
-         "recordType":"HOLDINGS",
-         "metadataParameters":{
-            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-            "languages":"$.instance.languages"
-         }
-      },
-      {
-         "fieldId":"holdings.metadata.updatedbyuserid",
-         "displayNameKey":"holdings.metadata.updatedByUserId",
-         "path":"$.holdings.metadata.updatedByUserId",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"holdings.metadata.updateddate",
-         "displayNameKey":"holdings.metadata.updatedDate",
-         "path":"$.holdings.metadata.updatedDate",
-         "recordType":"HOLDINGS"
-      },
-      {
-         "fieldId":"instance.alternativetitletypename.cover.title",
-         "displayNameKey":"instance.alternativeTitleTypeName",
-         "referenceDataValue":"Cover title",
-         "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.alternativetitletypename.running.title",
-         "displayNameKey":"instance.alternativeTitleTypeName",
-         "referenceDataValue":"Running title",
-         "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.corporate.name",
-         "displayNameKey":"instance.contributorName",
-         "referenceDataValue":"Corporate name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.meeting.name",
-         "displayNameKey":"instance.contributorName",
-         "referenceDataValue":"Meeting name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.personal.name",
-         "displayNameKey":"instance.contributorName",
-         "referenceDataValue":"Personal name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.primary.corporate.name",
-         "displayNameKey":"instance.contributorName.primary",
-         "referenceDataValue":"Corporate name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.primary.meeting.name",
-         "displayNameKey":"instance.contributorName.primary",
-         "referenceDataValue":"Meeting name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.contributorname.primary.personal.name",
-         "displayNameKey":"instance.contributorName.primary",
-         "referenceDataValue":"Personal name",
-         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.editions",
-         "displayNameKey":"instance.editions",
-         "path":"$.instance.editions",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.default",
-         "displayNameKey":"instance.electronic.access.linkText.default",
-         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.no.display.constant.generated",
-         "displayNameKey":"instance.electronic.access.linkText",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.no.information.provided",
-         "displayNameKey":"instance.electronic.access.linkText",
-         "referenceDataValue":"No information provided",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.related.resource",
-         "displayNameKey":"instance.electronic.access.linkText",
-         "referenceDataValue":"Related resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.resource",
-         "displayNameKey":"instance.electronic.access.linkText",
-         "referenceDataValue":"Resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.linktext.version.of.resource",
-         "displayNameKey":"instance.electronic.access.linkText",
-         "referenceDataValue":"Version of resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.default",
-         "displayNameKey":"instance.electronic.access.materialsSpecification.default",
-         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.no.display.constant.generated",
-         "displayNameKey":"instance.electronic.access.materialsSpecification",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.no.information.provided",
-         "displayNameKey":"instance.electronic.access.materialsSpecification",
-         "referenceDataValue":"No information provided",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.related.resource",
-         "displayNameKey":"instance.electronic.access.materialsSpecification",
-         "referenceDataValue":"Related resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.resource",
-         "displayNameKey":"instance.electronic.access.materialsSpecification",
-         "referenceDataValue":"Resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.materialsspecification.version.of.resource",
-         "displayNameKey":"instance.electronic.access.materialsSpecification",
-         "referenceDataValue":"Version of resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.default",
-         "displayNameKey":"instance.electronic.access.publicNote.default",
-         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.no.display.constant.generated",
-         "displayNameKey":"instance.electronic.access.publicNote",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.no.information.provided",
-         "displayNameKey":"instance.electronic.access.publicNote",
-         "referenceDataValue":"No information provided",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.related.resource",
-         "displayNameKey":"instance.electronic.access.publicNote",
-         "referenceDataValue":"Related resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.resource",
-         "displayNameKey":"instance.electronic.access.publicNote",
-         "referenceDataValue":"Resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.publicnote.version.of.resource",
-         "displayNameKey":"instance.electronic.access.publicNote",
-         "referenceDataValue":"Version of resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.default",
-         "displayNameKey":"instance.electronic.access.uri.default",
-         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.no.display.constant.generated",
-         "displayNameKey":"instance.electronic.access.uri",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.no.information.provided",
-         "displayNameKey":"instance.electronic.access.uri",
-         "referenceDataValue":"No information provided",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.related.resource",
-         "displayNameKey":"instance.electronic.access.uri",
-         "referenceDataValue":"Related resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.resource",
-         "displayNameKey":"instance.electronic.access.uri",
-         "referenceDataValue":"Resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.electronic.access.uri.version.of.resource",
-         "displayNameKey":"instance.electronic.access.uri",
-         "referenceDataValue":"Version of resource",
-         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.hrid",
-         "displayNameKey":"instance.hrid",
-         "path":"$.instance.hrid",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.id",
-         "displayNameKey":"instance.id",
-         "path":"$.instance.id",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.gpo.item.number",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"GPO item number",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.isbn",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"ISBN",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.issn",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"ISSN",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.lccn",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"LCCN",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.oclc",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"OCLC",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.identifiers.system.control.number",
-         "displayNameKey":"instance.identifiers",
-         "referenceDataValue":"System control number",
-         "path":"$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.instancetypeid.other",
-         "displayNameKey":"instance.instanceTypeId",
-         "referenceDataValue":"other",
-         "path":"$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.instancetypeid.text",
-         "displayNameKey":"instance.instanceTypeId",
-         "referenceDataValue":"text",
-         "path":"$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.languages",
-         "displayNameKey":"instance.languages",
-         "path":"$.instance.languages",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.metadata.createdbyuserid",
-         "displayNameKey":"instance.metadata.createdByUserId",
-         "path":"$.instance.metadata.createdByUserId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.metadata.createddate",
-         "displayNameKey":"instance.metadata.createdDate",
-         "path":"$.instance.metadata.createdDate",
-         "recordType":"INSTANCE",
-         "metadataParameters":{
-            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-            "languages":"$.instance.languages"
-         }
-      },
-      {
-         "fieldId":"instance.metadata.updatedbyuserid",
-         "displayNameKey":"instance.metadata.updatedByUserId",
-         "path":"$.instance.metadata.updatedByUserId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.metadata.updateddate",
-         "displayNameKey":"instance.metadata.updatedDate",
-         "path":"$.instance.metadata.updatedDate",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.modeofissuanceid.multipart.monograph",
-         "displayNameKey":"instance.modeOfIssuanceId",
-         "referenceDataValue":"multipart monograph",
-         "path":"$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.modeofissuanceid.single.unit",
-         "displayNameKey":"instance.modeOfIssuanceId",
-         "referenceDataValue":"single unit",
-         "path":"$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.source",
-         "displayNameKey":"instance.source",
-         "path":"$.instance.source",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.subjects",
-         "displayNameKey":"instance.subjects",
-         "path":"$.instance.subjects",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"instance.title",
-         "displayNameKey":"instance.title",
-         "path":"$.instance.title",
-         "recordType":"INSTANCE"
-      },
-      {
-         "fieldId":"item.barcode",
-         "displayNameKey":"item.barcode",
-         "path":"$.items[*].barcode",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.callnumber",
-         "displayNameKey":"item.callNumber",
-         "path":"$.item[*].effectiveCallNumberComponents.callNumber",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.callnumberprefix",
-         "displayNameKey":"item.callNumberPrefix",
-         "path":"$.item[*].effectiveCallNumberComponents.prefix",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.callnumbersuffix",
-         "displayNameKey":"item.callNumberSuffix",
-         "path":"$.item[*].effectiveCallNumberComponents.suffix",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.callnumbertype",
-         "displayNameKey":"item.callNumberType",
-         "path":"$.item[*].effectiveCallNumberComponents.typeId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.chronology",
-         "displayNameKey":"item.chronology",
-         "path":"$.items[*].chronology",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.copynumber",
-         "displayNameKey":"item.copyNumber",
-         "path":"$.items[*].copyNumber",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.descriptionofpieces",
-         "displayNameKey":"item.descriptionOfPieces",
-         "path":"$.items[*].descriptionOfPieces",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.default",
-         "displayNameKey":"item.electronic.access.linkText.default",
-         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.no.display.constant.generated",
-         "displayNameKey":"item.electronic.access.linkText",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.no.information.provided",
-         "displayNameKey":"item.electronic.access.linkText",
-         "referenceDataValue":"No information provided",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.related.resource",
-         "displayNameKey":"item.electronic.access.linkText",
-         "referenceDataValue":"Related resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.resource",
-         "displayNameKey":"item.electronic.access.linkText",
-         "referenceDataValue":"Resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.linktext.version.of.resource",
-         "displayNameKey":"item.electronic.access.linkText",
-         "referenceDataValue":"Version of resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.default",
-         "displayNameKey":"item.electronic.access.materialsSpecification.default",
-         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.no.display.constant.generated",
-         "displayNameKey":"item.electronic.access.materialsSpecification",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.no.information.provided",
-         "displayNameKey":"item.electronic.access.materialsSpecification",
-         "referenceDataValue":"No information provided",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.related.resource",
-         "displayNameKey":"item.electronic.access.materialsSpecification",
-         "referenceDataValue":"Related resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.resource",
-         "displayNameKey":"item.electronic.access.materialsSpecification",
-         "referenceDataValue":"Resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.materialsspecification.version.of.resource",
-         "displayNameKey":"item.electronic.access.materialsSpecification",
-         "referenceDataValue":"Version of resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.default",
-         "displayNameKey":"item.electronic.access.publicNote.default",
-         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.no.display.constant.generated",
-         "displayNameKey":"item.electronic.access.publicNote",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.no.information.provided",
-         "displayNameKey":"item.electronic.access.publicNote",
-         "referenceDataValue":"No information provided",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.related.resource",
-         "displayNameKey":"item.electronic.access.publicNote",
-         "referenceDataValue":"Related resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.resource",
-         "displayNameKey":"item.electronic.access.publicNote",
-         "referenceDataValue":"Resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.publicnote.version.of.resource",
-         "displayNameKey":"item.electronic.access.publicNote",
-         "referenceDataValue":"Version of resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.default",
-         "displayNameKey":"item.electronic.access.uri.default",
-         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.no.display.constant.generated",
-         "displayNameKey":"item.electronic.access.uri",
-         "referenceDataValue":"No display constant generated",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.no.information.provided",
-         "displayNameKey":"item.electronic.access.uri",
-         "referenceDataValue":"No information provided",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.related.resource",
-         "displayNameKey":"item.electronic.access.uri",
-         "referenceDataValue":"Related resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.resource",
-         "displayNameKey":"item.electronic.access.uri",
-         "referenceDataValue":"Resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.electronic.access.uri.version.of.resource",
-         "displayNameKey":"item.electronic.access.uri",
-         "referenceDataValue":"Version of resource",
-         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.enumeration",
-         "displayNameKey":"item.enumeration",
-         "path":"$.items[*].enumeration",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.holdingsrecordid",
-         "displayNameKey":"item.holdingsRecordId",
-         "path":"$.items[*].holdingsRecordId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.hrid",
-         "displayNameKey":"item.hrid",
-         "path":"$.item.hrid",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.id",
-         "displayNameKey":"item.id",
-         "path":"$.item.id",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.itemnotetypeid.action.note",
-         "displayNameKey":"item.itemNoteTypeId",
-         "referenceDataValue":"Action note",
-         "path":"$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && (!(@.staffOnly) || @.staffOnly == false))].note",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.itemnotetypeid.binding",
-         "displayNameKey":"item.itemNoteTypeId",
-         "referenceDataValue":"Binding",
-         "path":"$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && (!(@.staffOnly) || @.staffOnly == false))].note",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.itemnotetypeid.staffonly.action.note",
-         "displayNameKey":"item.itemNoteTypeId.staffOnly",
-         "referenceDataValue":"Action note",
-         "path":"$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && ((@.staffOnly) && @.staffOnly == true))].note",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.itemnotetypeid.staffonly.binding",
-         "displayNameKey":"item.itemNoteTypeId.staffOnly",
-         "referenceDataValue":"Binding",
-         "path":"$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && ((@.staffOnly) && @.staffOnly == true))].note",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.materialtypeid.book",
-         "displayNameKey":"item.materialTypeId",
-         "referenceDataValue":"book",
-         "path":"$.items[*].materialTypeId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.materialtypeid.dvd",
-         "displayNameKey":"item.materialTypeId",
-         "referenceDataValue":"dvd",
-         "path":"$.items[*].materialTypeId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.metadata.createdbyuserid",
-         "displayNameKey":"item.metadata.createdByUserId",
-         "path":"$.item.metadata.createdByUserId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.metadata.createddate",
-         "displayNameKey":"item.metadata.createdDate",
-         "path":"$.item.metadata.createdDate",
-         "recordType":"ITEM",
-         "metadataParameters":{
-            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-            "languages":"$.instance.languages"
-         }
-      },
-      {
-         "fieldId":"item.metadata.updatedbyuserid",
-         "displayNameKey":"item.metadata.updatedByUserId",
-         "path":"$.item.metadata.updatedByUserId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.metadata.updateddate",
-         "displayNameKey":"item.metadata.updatedDate",
-         "path":"$.item.metadata.updatedDate",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.numberofpieces",
-         "displayNameKey":"item.numberOfPieces",
-         "path":"$.items[*].numberOfPieces",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.permanentloantypeid.can.circulate",
-         "displayNameKey":"item.permanentLoanTypeId",
-         "referenceDataValue":"Can circulate",
-         "path":"$.items[*].permanentLoanTypeId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.permanentloantypeid.reading.room",
-         "displayNameKey":"item.permanentLoanTypeId",
-         "referenceDataValue":"Reading room",
-         "path":"$.items[*].permanentLoanTypeId",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.status",
-         "displayNameKey":"item.status",
-         "path":"$.items[*].status.name",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.volume",
-         "displayNameKey":"item.volume",
-         "path":"$.items[*].volume",
-         "recordType":"ITEM"
-      },
-      {
-         "fieldId":"item.yearcaption",
-         "displayNameKey":"item.yearCaption",
-         "path":"$.items[*].yearCaption",
-         "recordType":"ITEM"
-      }
-   ],
-   "totalRecords":144
+	"transformationFields": [
+		{
+			"fieldId": "holdings.callnumber",
+			"displayNameKey": "holdings.callNumber",
+			"path": "$.holdings[*].callNumber",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.callnumberprefix",
+			"displayNameKey": "holdings.callNumberPrefix",
+			"path": "$.holdings[*].callNumberPrefix",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.callnumbersuffix",
+			"displayNameKey": "holdings.callNumberSuffix",
+			"path": "$.holdings[*].callNumberSuffix",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.callnumbertype",
+			"displayNameKey": "holdings.callNumberType",
+			"path": "$.holdings[*].callNumberTypeId",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.default",
+			"displayNameKey": "holdings.electronic.access.linkText.default",
+			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.no.display.constant.generated",
+			"displayNameKey": "holdings.electronic.access.linkText",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.no.information.provided",
+			"displayNameKey": "holdings.electronic.access.linkText",
+			"referenceDataValue": "No information provided",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.related.resource",
+			"displayNameKey": "holdings.electronic.access.linkText",
+			"referenceDataValue": "Related resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.resource",
+			"displayNameKey": "holdings.electronic.access.linkText",
+			"referenceDataValue": "Resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.linktext.version.of.resource",
+			"displayNameKey": "holdings.electronic.access.linkText",
+			"referenceDataValue": "Version of resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.default",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification.default",
+			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.no.display.constant.generated",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.no.information.provided",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification",
+			"referenceDataValue": "No information provided",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.related.resource",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification",
+			"referenceDataValue": "Related resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.resource",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification",
+			"referenceDataValue": "Resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.materialsspecification.version.of.resource",
+			"displayNameKey": "holdings.electronic.access.materialsSpecification",
+			"referenceDataValue": "Version of resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.default",
+			"displayNameKey": "holdings.electronic.access.publicNote.default",
+			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.no.display.constant.generated",
+			"displayNameKey": "holdings.electronic.access.publicNote",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.no.information.provided",
+			"displayNameKey": "holdings.electronic.access.publicNote",
+			"referenceDataValue": "No information provided",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.related.resource",
+			"displayNameKey": "holdings.electronic.access.publicNote",
+			"referenceDataValue": "Related resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.resource",
+			"displayNameKey": "holdings.electronic.access.publicNote",
+			"referenceDataValue": "Resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.publicnote.version.of.resource",
+			"displayNameKey": "holdings.electronic.access.publicNote",
+			"referenceDataValue": "Version of resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.default",
+			"displayNameKey": "holdings.electronic.access.uri.default",
+			"path": "$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.no.display.constant.generated",
+			"displayNameKey": "holdings.electronic.access.uri",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.no.information.provided",
+			"displayNameKey": "holdings.electronic.access.uri",
+			"referenceDataValue": "No information provided",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.related.resource",
+			"displayNameKey": "holdings.electronic.access.uri",
+			"referenceDataValue": "Related resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.resource",
+			"displayNameKey": "holdings.electronic.access.uri",
+			"referenceDataValue": "Resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.electronic.access.uri.version.of.resource",
+			"displayNameKey": "holdings.electronic.access.uri",
+			"referenceDataValue": "Version of resource",
+			"path": "$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.holdingnotetypeid.copy.note",
+			"displayNameKey": "holdings.holdingNoteTypeId",
+			"referenceDataValue": "Copy note",
+			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && (!(@.staffOnly) || @.staffOnly == false))].note",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.holdingnotetypeid.electronic.bookplate",
+			"displayNameKey": "holdings.holdingNoteTypeId",
+			"referenceDataValue": "Electronic bookplate",
+			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && (!(@.staffOnly) || @.staffOnly == false))].note",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.holdingnotetypeid.staffonly.copy.note",
+			"displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
+			"referenceDataValue": "Copy note",
+			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && ((@.staffOnly) && @.staffOnly == true))].note",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.holdingnotetypeid.staffonly.electronic.bookplate",
+			"displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
+			"referenceDataValue": "Electronic bookplate",
+			"path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && ((@.staffOnly) && @.staffOnly == true))].note",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.hrid",
+			"displayNameKey": "holdings.hrid",
+			"path": "$.holdings.hrid",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.id",
+			"displayNameKey": "holdings.id",
+			"path": "$.holdings.id",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.instanceid",
+			"displayNameKey": "holdings.instanceId",
+			"path": "$.holdings[*].instanceId",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.metadata.createdbyuserid",
+			"displayNameKey": "holdings.metadata.createdByUserId",
+			"path": "$.holdings.metadata.createdByUserId",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.metadata.createddate",
+			"displayNameKey": "holdings.metadata.createdDate",
+			"path": "$.holdings.metadata.createdDate",
+			"recordType": "HOLDINGS",
+			"metadataParameters": {
+				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
+				"languages": "$.instance.languages"
+			}
+		},
+		{
+			"fieldId": "holdings.metadata.updatedbyuserid",
+			"displayNameKey": "holdings.metadata.updatedByUserId",
+			"path": "$.holdings.metadata.updatedByUserId",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "holdings.metadata.updateddate",
+			"displayNameKey": "holdings.metadata.updatedDate",
+			"path": "$.holdings.metadata.updatedDate",
+			"recordType": "HOLDINGS"
+		},
+		{
+			"fieldId": "instance.alternativetitletypename.cover.title",
+			"displayNameKey": "instance.alternativeTitleTypeName",
+			"referenceDataValue": "Cover title",
+			"path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.alternativetitletypename.running.title",
+			"displayNameKey": "instance.alternativeTitleTypeName",
+			"referenceDataValue": "Running title",
+			"path": "$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.corporate.name",
+			"displayNameKey": "instance.contributorName",
+			"referenceDataValue": "Corporate name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.meeting.name",
+			"displayNameKey": "instance.contributorName",
+			"referenceDataValue": "Meeting name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.personal.name",
+			"displayNameKey": "instance.contributorName",
+			"referenceDataValue": "Personal name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.primary.corporate.name",
+			"displayNameKey": "instance.contributorName.primary",
+			"referenceDataValue": "Corporate name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.primary.meeting.name",
+			"displayNameKey": "instance.contributorName.primary",
+			"referenceDataValue": "Meeting name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.contributorname.primary.personal.name",
+			"displayNameKey": "instance.contributorName.primary",
+			"referenceDataValue": "Personal name",
+			"path": "$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.editions",
+			"displayNameKey": "instance.editions",
+			"path": "$.instance.editions",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.default",
+			"displayNameKey": "instance.electronic.access.linkText.default",
+			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.no.display.constant.generated",
+			"displayNameKey": "instance.electronic.access.linkText",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.no.information.provided",
+			"displayNameKey": "instance.electronic.access.linkText",
+			"referenceDataValue": "No information provided",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.related.resource",
+			"displayNameKey": "instance.electronic.access.linkText",
+			"referenceDataValue": "Related resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.resource",
+			"displayNameKey": "instance.electronic.access.linkText",
+			"referenceDataValue": "Resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.linktext.version.of.resource",
+			"displayNameKey": "instance.electronic.access.linkText",
+			"referenceDataValue": "Version of resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.default",
+			"displayNameKey": "instance.electronic.access.materialsSpecification.default",
+			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.no.display.constant.generated",
+			"displayNameKey": "instance.electronic.access.materialsSpecification",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.no.information.provided",
+			"displayNameKey": "instance.electronic.access.materialsSpecification",
+			"referenceDataValue": "No information provided",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.related.resource",
+			"displayNameKey": "instance.electronic.access.materialsSpecification",
+			"referenceDataValue": "Related resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.resource",
+			"displayNameKey": "instance.electronic.access.materialsSpecification",
+			"referenceDataValue": "Resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.materialsspecification.version.of.resource",
+			"displayNameKey": "instance.electronic.access.materialsSpecification",
+			"referenceDataValue": "Version of resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.default",
+			"displayNameKey": "instance.electronic.access.publicNote.default",
+			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.no.display.constant.generated",
+			"displayNameKey": "instance.electronic.access.publicNote",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.no.information.provided",
+			"displayNameKey": "instance.electronic.access.publicNote",
+			"referenceDataValue": "No information provided",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.related.resource",
+			"displayNameKey": "instance.electronic.access.publicNote",
+			"referenceDataValue": "Related resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.resource",
+			"displayNameKey": "instance.electronic.access.publicNote",
+			"referenceDataValue": "Resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.publicnote.version.of.resource",
+			"displayNameKey": "instance.electronic.access.publicNote",
+			"referenceDataValue": "Version of resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.default",
+			"displayNameKey": "instance.electronic.access.uri.default",
+			"path": "$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.no.display.constant.generated",
+			"displayNameKey": "instance.electronic.access.uri",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.no.information.provided",
+			"displayNameKey": "instance.electronic.access.uri",
+			"referenceDataValue": "No information provided",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.related.resource",
+			"displayNameKey": "instance.electronic.access.uri",
+			"referenceDataValue": "Related resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.resource",
+			"displayNameKey": "instance.electronic.access.uri",
+			"referenceDataValue": "Resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.electronic.access.uri.version.of.resource",
+			"displayNameKey": "instance.electronic.access.uri",
+			"referenceDataValue": "Version of resource",
+			"path": "$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.hrid",
+			"displayNameKey": "instance.hrid",
+			"path": "$.instance.hrid",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.id",
+			"displayNameKey": "instance.id",
+			"path": "$.instance.id",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.gpo.item.number",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "GPO item number",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.isbn",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "ISBN",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.issn",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "ISSN",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.lccn",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "LCCN",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.oclc",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "OCLC",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.identifiers.system.control.number",
+			"displayNameKey": "instance.identifiers",
+			"referenceDataValue": "System control number",
+			"path": "$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.instancetypeid.other",
+			"displayNameKey": "instance.instanceTypeId",
+			"referenceDataValue": "other",
+			"path": "$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.instancetypeid.text",
+			"displayNameKey": "instance.instanceTypeId",
+			"referenceDataValue": "text",
+			"path": "$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.languages",
+			"displayNameKey": "instance.languages",
+			"path": "$.instance.languages",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.metadata.createdbyuserid",
+			"displayNameKey": "instance.metadata.createdByUserId",
+			"path": "$.instance.metadata.createdByUserId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.metadata.createddate",
+			"displayNameKey": "instance.metadata.createdDate",
+			"path": "$.instance.metadata.createdDate",
+			"recordType": "INSTANCE",
+			"metadataParameters": {
+				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
+				"languages": "$.instance.languages"
+			}
+		},
+		{
+			"fieldId": "instance.metadata.updatedbyuserid",
+			"displayNameKey": "instance.metadata.updatedByUserId",
+			"path": "$.instance.metadata.updatedByUserId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.metadata.updateddate",
+			"displayNameKey": "instance.metadata.updatedDate",
+			"path": "$.instance.metadata.updatedDate",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.modeofissuanceid.multipart.monograph",
+			"displayNameKey": "instance.modeOfIssuanceId",
+			"referenceDataValue": "multipart monograph",
+			"path": "$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.modeofissuanceid.single.unit",
+			"displayNameKey": "instance.modeOfIssuanceId",
+			"referenceDataValue": "single unit",
+			"path": "$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.source",
+			"displayNameKey": "instance.source",
+			"path": "$.instance.source",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.subjects",
+			"displayNameKey": "instance.subjects",
+			"path": "$.instance.subjects",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "instance.title",
+			"displayNameKey": "instance.title",
+			"path": "$.instance.title",
+			"recordType": "INSTANCE"
+		},
+		{
+			"fieldId": "item.barcode",
+			"displayNameKey": "item.barcode",
+			"path": "$.items[*].barcode",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.callnumber",
+			"displayNameKey": "item.callNumber",
+			"path": "$.item[*].effectiveCallNumberComponents.callNumber",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.callnumberprefix",
+			"displayNameKey": "item.callNumberPrefix",
+			"path": "$.item[*].effectiveCallNumberComponents.prefix",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.callnumbersuffix",
+			"displayNameKey": "item.callNumberSuffix",
+			"path": "$.item[*].effectiveCallNumberComponents.suffix",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.callnumbertype",
+			"displayNameKey": "item.callNumberType",
+			"path": "$.item[*].effectiveCallNumberComponents.typeId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.chronology",
+			"displayNameKey": "item.chronology",
+			"path": "$.items[*].chronology",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.copynumber",
+			"displayNameKey": "item.copyNumber",
+			"path": "$.items[*].copyNumber",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.descriptionofpieces",
+			"displayNameKey": "item.descriptionOfPieces",
+			"path": "$.items[*].descriptionOfPieces",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.default",
+			"displayNameKey": "item.electronic.access.linkText.default",
+			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.no.display.constant.generated",
+			"displayNameKey": "item.electronic.access.linkText",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.no.information.provided",
+			"displayNameKey": "item.electronic.access.linkText",
+			"referenceDataValue": "No information provided",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.related.resource",
+			"displayNameKey": "item.electronic.access.linkText",
+			"referenceDataValue": "Related resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.resource",
+			"displayNameKey": "item.electronic.access.linkText",
+			"referenceDataValue": "Resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.linktext.version.of.resource",
+			"displayNameKey": "item.electronic.access.linkText",
+			"referenceDataValue": "Version of resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.default",
+			"displayNameKey": "item.electronic.access.materialsSpecification.default",
+			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.no.display.constant.generated",
+			"displayNameKey": "item.electronic.access.materialsSpecification",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.no.information.provided",
+			"displayNameKey": "item.electronic.access.materialsSpecification",
+			"referenceDataValue": "No information provided",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.related.resource",
+			"displayNameKey": "item.electronic.access.materialsSpecification",
+			"referenceDataValue": "Related resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.resource",
+			"displayNameKey": "item.electronic.access.materialsSpecification",
+			"referenceDataValue": "Resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.materialsspecification.version.of.resource",
+			"displayNameKey": "item.electronic.access.materialsSpecification",
+			"referenceDataValue": "Version of resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.default",
+			"displayNameKey": "item.electronic.access.publicNote.default",
+			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.no.display.constant.generated",
+			"displayNameKey": "item.electronic.access.publicNote",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.no.information.provided",
+			"displayNameKey": "item.electronic.access.publicNote",
+			"referenceDataValue": "No information provided",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.related.resource",
+			"displayNameKey": "item.electronic.access.publicNote",
+			"referenceDataValue": "Related resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.resource",
+			"displayNameKey": "item.electronic.access.publicNote",
+			"referenceDataValue": "Resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.publicnote.version.of.resource",
+			"displayNameKey": "item.electronic.access.publicNote",
+			"referenceDataValue": "Version of resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.default",
+			"displayNameKey": "item.electronic.access.uri.default",
+			"path": "$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.no.display.constant.generated",
+			"displayNameKey": "item.electronic.access.uri",
+			"referenceDataValue": "No display constant generated",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.no.information.provided",
+			"displayNameKey": "item.electronic.access.uri",
+			"referenceDataValue": "No information provided",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.related.resource",
+			"displayNameKey": "item.electronic.access.uri",
+			"referenceDataValue": "Related resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.resource",
+			"displayNameKey": "item.electronic.access.uri",
+			"referenceDataValue": "Resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.electronic.access.uri.version.of.resource",
+			"displayNameKey": "item.electronic.access.uri",
+			"referenceDataValue": "Version of resource",
+			"path": "$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.enumeration",
+			"displayNameKey": "item.enumeration",
+			"path": "$.items[*].enumeration",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.holdingsrecordid",
+			"displayNameKey": "item.holdingsRecordId",
+			"path": "$.items[*].holdingsRecordId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.hrid",
+			"displayNameKey": "item.hrid",
+			"path": "$.item.hrid",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.id",
+			"displayNameKey": "item.id",
+			"path": "$.item.id",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.itemnotetypeid.action.note",
+			"displayNameKey": "item.itemNoteTypeId",
+			"referenceDataValue": "Action note",
+			"path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && (!(@.staffOnly) || @.staffOnly == false))].note",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.itemnotetypeid.binding",
+			"displayNameKey": "item.itemNoteTypeId",
+			"referenceDataValue": "Binding",
+			"path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && (!(@.staffOnly) || @.staffOnly == false))].note",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.itemnotetypeid.staffonly.action.note",
+			"displayNameKey": "item.itemNoteTypeId.staffOnly",
+			"referenceDataValue": "Action note",
+			"path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && ((@.staffOnly) && @.staffOnly == true))].note",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.itemnotetypeid.staffonly.binding",
+			"displayNameKey": "item.itemNoteTypeId.staffOnly",
+			"referenceDataValue": "Binding",
+			"path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && ((@.staffOnly) && @.staffOnly == true))].note",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.materialtypeid.book",
+			"displayNameKey": "item.materialTypeId",
+			"referenceDataValue": "book",
+			"path": "$.items[*].materialTypeId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.materialtypeid.dvd",
+			"displayNameKey": "item.materialTypeId",
+			"referenceDataValue": "dvd",
+			"path": "$.items[*].materialTypeId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.metadata.createdbyuserid",
+			"displayNameKey": "item.metadata.createdByUserId",
+			"path": "$.item.metadata.createdByUserId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.metadata.createddate",
+			"displayNameKey": "item.metadata.createdDate",
+			"path": "$.item.metadata.createdDate",
+			"recordType": "ITEM",
+			"metadataParameters": {
+				"datesOfPublication": "$.instance.publication[*].dateOfPublication",
+				"languages": "$.instance.languages"
+			}
+		},
+		{
+			"fieldId": "item.metadata.updatedbyuserid",
+			"displayNameKey": "item.metadata.updatedByUserId",
+			"path": "$.item.metadata.updatedByUserId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.metadata.updateddate",
+			"displayNameKey": "item.metadata.updatedDate",
+			"path": "$.item.metadata.updatedDate",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.numberofpieces",
+			"displayNameKey": "item.numberOfPieces",
+			"path": "$.items[*].numberOfPieces",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.permanentloantypeid.can.circulate",
+			"displayNameKey": "item.permanentLoanTypeId",
+			"referenceDataValue": "Can circulate",
+			"path": "$.items[*].permanentLoanTypeId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.permanentloantypeid.reading.room",
+			"displayNameKey": "item.permanentLoanTypeId",
+			"referenceDataValue": "Reading room",
+			"path": "$.items[*].permanentLoanTypeId",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.status",
+			"displayNameKey": "item.status",
+			"path": "$.items[*].status.name",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.volume",
+			"displayNameKey": "item.volume",
+			"path": "$.items[*].volume",
+			"recordType": "ITEM"
+		},
+		{
+			"fieldId": "item.yearcaption",
+			"displayNameKey": "item.yearCaption",
+			"path": "$.items[*].yearCaption",
+			"recordType": "ITEM"
+		}
+	],
+	"totalRecords": 144
 }

--- a/src/test/resources/mapping/expectedTransformationFields.json
+++ b/src/test/resources/mapping/expectedTransformationFields.json
@@ -1,971 +1,971 @@
 {
-  "transformationFields":[
-    {
-      "fieldId":"holdings.callnumber",
-      "displayNameKey":"holdings.callNumber",
-      "path":"$.holdings[*].callNumber",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.callnumberprefix",
-      "displayNameKey":"holdings.callNumberPrefix",
-      "path":"$.holdings[*].callNumberPrefix",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.callnumbersuffix",
-      "displayNameKey":"holdings.callNumberSuffix",
-      "path":"$.holdings[*].callNumberSuffix",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.callnumbertype",
-      "displayNameKey":"holdings.callNumberType",
-      "path":"$.holdings[*].callNumberTypeId",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext.no.display.constant.generated",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext.no.information.provided",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "referenceDataValue":"No information provided",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext.related.resource",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "referenceDataValue":"Related resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext.resource",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "referenceDataValue":"Resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.linktext.version.of.resource",
-      "displayNameKey":"holdings.electronic.access.linkText",
-      "referenceDataValue":"Version of resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification.no.display.constant.generated",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification.no.information.provided",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "referenceDataValue":"No information provided",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification.related.resource",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "referenceDataValue":"Related resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification.resource",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "referenceDataValue":"Resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.materialsspecification.version.of.resource",
-      "displayNameKey":"holdings.electronic.access.materialsSpecification",
-      "referenceDataValue":"Version of resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote.no.display.constant.generated",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote.no.information.provided",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "referenceDataValue":"No information provided",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote.related.resource",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "referenceDataValue":"Related resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote.resource",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "referenceDataValue":"Resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.publicnote.version.of.resource",
-      "displayNameKey":"holdings.electronic.access.publicNote",
-      "referenceDataValue":"Version of resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri.no.display.constant.generated",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri.no.information.provided",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "referenceDataValue":"No information provided",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri.related.resource",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "referenceDataValue":"Related resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri.resource",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "referenceDataValue":"Resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.electronic.access.uri.version.of.resource",
-      "displayNameKey":"holdings.electronic.access.uri",
-      "referenceDataValue":"Version of resource",
-      "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.hrid",
-      "displayNameKey":"holdings.hrid",
-      "path":"$.holdings.hrid",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.id",
-      "displayNameKey":"holdings.id",
-      "path":"$.holdings.id",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.instanceid",
-      "displayNameKey":"holdings.instanceId",
-      "path":"$.holdings[*].instanceId",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.metadata.createdbyuserid",
-      "displayNameKey":"holdings.metadata.createdByUserId",
-      "path":"$.holdings.metadata.createdByUserId",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.metadata.createddate",
-      "displayNameKey":"holdings.metadata.createdDate",
-      "path":"$.holdings.metadata.createdDate",
-      "recordType":"HOLDINGS",
-      "metadataParameters":{
-        "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-        "languages":"$.instance.languages"
+   "transformationFields":[
+      {
+         "fieldId":"holdings.callnumber",
+         "displayNameKey":"holdings.callNumber",
+         "path":"$.holdings[*].callNumber",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.callnumberprefix",
+         "displayNameKey":"holdings.callNumberPrefix",
+         "path":"$.holdings[*].callNumberPrefix",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.callnumbersuffix",
+         "displayNameKey":"holdings.callNumberSuffix",
+         "path":"$.holdings[*].callNumberSuffix",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.callnumbertype",
+         "displayNameKey":"holdings.callNumberType",
+         "path":"$.holdings[*].callNumberTypeId",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.default",
+         "displayNameKey":"holdings.electronic.access.linkText.default",
+         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey":"holdings.electronic.access.linkText",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.no.information.provided",
+         "displayNameKey":"holdings.electronic.access.linkText",
+         "referenceDataValue":"No information provided",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.related.resource",
+         "displayNameKey":"holdings.electronic.access.linkText",
+         "referenceDataValue":"Related resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.resource",
+         "displayNameKey":"holdings.electronic.access.linkText",
+         "referenceDataValue":"Resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.linktext.version.of.resource",
+         "displayNameKey":"holdings.electronic.access.linkText",
+         "referenceDataValue":"Version of resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.default",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification.default",
+         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification",
+         "referenceDataValue":"No information provided",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.related.resource",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification",
+         "referenceDataValue":"Related resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.resource",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification",
+         "referenceDataValue":"Resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey":"holdings.electronic.access.materialsSpecification",
+         "referenceDataValue":"Version of resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.default",
+         "displayNameKey":"holdings.electronic.access.publicNote.default",
+         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey":"holdings.electronic.access.publicNote",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.no.information.provided",
+         "displayNameKey":"holdings.electronic.access.publicNote",
+         "referenceDataValue":"No information provided",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.related.resource",
+         "displayNameKey":"holdings.electronic.access.publicNote",
+         "referenceDataValue":"Related resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.resource",
+         "displayNameKey":"holdings.electronic.access.publicNote",
+         "referenceDataValue":"Resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.publicnote.version.of.resource",
+         "displayNameKey":"holdings.electronic.access.publicNote",
+         "referenceDataValue":"Version of resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.default",
+         "displayNameKey":"holdings.electronic.access.uri.default",
+         "path":"$.holdings.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey":"holdings.electronic.access.uri",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.no.information.provided",
+         "displayNameKey":"holdings.electronic.access.uri",
+         "referenceDataValue":"No information provided",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.related.resource",
+         "displayNameKey":"holdings.electronic.access.uri",
+         "referenceDataValue":"Related resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.resource",
+         "displayNameKey":"holdings.electronic.access.uri",
+         "referenceDataValue":"Resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.electronic.access.uri.version.of.resource",
+         "displayNameKey":"holdings.electronic.access.uri",
+         "referenceDataValue":"Version of resource",
+         "path":"$.holdings.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.holdingnotetypeid.copy.note",
+         "displayNameKey":"holdings.holdingNoteTypeId",
+         "referenceDataValue":"Copy note",
+         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.holdingnotetypeid.electronic.bookplate",
+         "displayNameKey":"holdings.holdingNoteTypeId",
+         "referenceDataValue":"Electronic bookplate",
+         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.holdingnotetypeid.staffonly.copy.note",
+         "displayNameKey":"holdings.holdingNoteTypeId.staffOnly",
+         "referenceDataValue":"Copy note",
+         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.holdingnotetypeid.staffonly.electronic.bookplate",
+         "displayNameKey":"holdings.holdingNoteTypeId.staffOnly",
+         "referenceDataValue":"Electronic bookplate",
+         "path":"$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.hrid",
+         "displayNameKey":"holdings.hrid",
+         "path":"$.holdings.hrid",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.id",
+         "displayNameKey":"holdings.id",
+         "path":"$.holdings.id",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.instanceid",
+         "displayNameKey":"holdings.instanceId",
+         "path":"$.holdings[*].instanceId",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.metadata.createdbyuserid",
+         "displayNameKey":"holdings.metadata.createdByUserId",
+         "path":"$.holdings.metadata.createdByUserId",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.metadata.createddate",
+         "displayNameKey":"holdings.metadata.createdDate",
+         "path":"$.holdings.metadata.createdDate",
+         "recordType":"HOLDINGS",
+         "metadataParameters":{
+            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
+            "languages":"$.instance.languages"
+         }
+      },
+      {
+         "fieldId":"holdings.metadata.updatedbyuserid",
+         "displayNameKey":"holdings.metadata.updatedByUserId",
+         "path":"$.holdings.metadata.updatedByUserId",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"holdings.metadata.updateddate",
+         "displayNameKey":"holdings.metadata.updatedDate",
+         "path":"$.holdings.metadata.updatedDate",
+         "recordType":"HOLDINGS"
+      },
+      {
+         "fieldId":"instance.alternativetitletypename.cover.title",
+         "displayNameKey":"instance.alternativeTitleTypeName",
+         "referenceDataValue":"Cover title",
+         "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.alternativetitletypename.running.title",
+         "displayNameKey":"instance.alternativeTitleTypeName",
+         "referenceDataValue":"Running title",
+         "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.corporate.name",
+         "displayNameKey":"instance.contributorName",
+         "referenceDataValue":"Corporate name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.meeting.name",
+         "displayNameKey":"instance.contributorName",
+         "referenceDataValue":"Meeting name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.personal.name",
+         "displayNameKey":"instance.contributorName",
+         "referenceDataValue":"Personal name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.primary.corporate.name",
+         "displayNameKey":"instance.contributorName.primary",
+         "referenceDataValue":"Corporate name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.primary.meeting.name",
+         "displayNameKey":"instance.contributorName.primary",
+         "referenceDataValue":"Meeting name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.contributorname.primary.personal.name",
+         "displayNameKey":"instance.contributorName.primary",
+         "referenceDataValue":"Personal name",
+         "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.editions",
+         "displayNameKey":"instance.editions",
+         "path":"$.instance.editions",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.default",
+         "displayNameKey":"instance.electronic.access.linkText.default",
+         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey":"instance.electronic.access.linkText",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.no.information.provided",
+         "displayNameKey":"instance.electronic.access.linkText",
+         "referenceDataValue":"No information provided",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.related.resource",
+         "displayNameKey":"instance.electronic.access.linkText",
+         "referenceDataValue":"Related resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.resource",
+         "displayNameKey":"instance.electronic.access.linkText",
+         "referenceDataValue":"Resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.linktext.version.of.resource",
+         "displayNameKey":"instance.electronic.access.linkText",
+         "referenceDataValue":"Version of resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.default",
+         "displayNameKey":"instance.electronic.access.materialsSpecification.default",
+         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey":"instance.electronic.access.materialsSpecification",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey":"instance.electronic.access.materialsSpecification",
+         "referenceDataValue":"No information provided",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.related.resource",
+         "displayNameKey":"instance.electronic.access.materialsSpecification",
+         "referenceDataValue":"Related resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.resource",
+         "displayNameKey":"instance.electronic.access.materialsSpecification",
+         "referenceDataValue":"Resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey":"instance.electronic.access.materialsSpecification",
+         "referenceDataValue":"Version of resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.default",
+         "displayNameKey":"instance.electronic.access.publicNote.default",
+         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey":"instance.electronic.access.publicNote",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.no.information.provided",
+         "displayNameKey":"instance.electronic.access.publicNote",
+         "referenceDataValue":"No information provided",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.related.resource",
+         "displayNameKey":"instance.electronic.access.publicNote",
+         "referenceDataValue":"Related resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.resource",
+         "displayNameKey":"instance.electronic.access.publicNote",
+         "referenceDataValue":"Resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.publicnote.version.of.resource",
+         "displayNameKey":"instance.electronic.access.publicNote",
+         "referenceDataValue":"Version of resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.default",
+         "displayNameKey":"instance.electronic.access.uri.default",
+         "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey":"instance.electronic.access.uri",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.no.information.provided",
+         "displayNameKey":"instance.electronic.access.uri",
+         "referenceDataValue":"No information provided",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.related.resource",
+         "displayNameKey":"instance.electronic.access.uri",
+         "referenceDataValue":"Related resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.resource",
+         "displayNameKey":"instance.electronic.access.uri",
+         "referenceDataValue":"Resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.electronic.access.uri.version.of.resource",
+         "displayNameKey":"instance.electronic.access.uri",
+         "referenceDataValue":"Version of resource",
+         "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.hrid",
+         "displayNameKey":"instance.hrid",
+         "path":"$.instance.hrid",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.id",
+         "displayNameKey":"instance.id",
+         "path":"$.instance.id",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.gpo.item.number",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"GPO item number",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.isbn",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"ISBN",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.issn",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"ISSN",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.lccn",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"LCCN",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.oclc",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"OCLC",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.identifiers.system.control.number",
+         "displayNameKey":"instance.identifiers",
+         "referenceDataValue":"System control number",
+         "path":"$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.instancetypeid.other",
+         "displayNameKey":"instance.instanceTypeId",
+         "referenceDataValue":"other",
+         "path":"$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.instancetypeid.text",
+         "displayNameKey":"instance.instanceTypeId",
+         "referenceDataValue":"text",
+         "path":"$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.languages",
+         "displayNameKey":"instance.languages",
+         "path":"$.instance.languages",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.metadata.createdbyuserid",
+         "displayNameKey":"instance.metadata.createdByUserId",
+         "path":"$.instance.metadata.createdByUserId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.metadata.createddate",
+         "displayNameKey":"instance.metadata.createdDate",
+         "path":"$.instance.metadata.createdDate",
+         "recordType":"INSTANCE",
+         "metadataParameters":{
+            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
+            "languages":"$.instance.languages"
+         }
+      },
+      {
+         "fieldId":"instance.metadata.updatedbyuserid",
+         "displayNameKey":"instance.metadata.updatedByUserId",
+         "path":"$.instance.metadata.updatedByUserId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.metadata.updateddate",
+         "displayNameKey":"instance.metadata.updatedDate",
+         "path":"$.instance.metadata.updatedDate",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.modeofissuanceid.multipart.monograph",
+         "displayNameKey":"instance.modeOfIssuanceId",
+         "referenceDataValue":"multipart monograph",
+         "path":"$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.modeofissuanceid.single.unit",
+         "displayNameKey":"instance.modeOfIssuanceId",
+         "referenceDataValue":"single unit",
+         "path":"$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.source",
+         "displayNameKey":"instance.source",
+         "path":"$.instance.source",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.subjects",
+         "displayNameKey":"instance.subjects",
+         "path":"$.instance.subjects",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"instance.title",
+         "displayNameKey":"instance.title",
+         "path":"$.instance.title",
+         "recordType":"INSTANCE"
+      },
+      {
+         "fieldId":"item.barcode",
+         "displayNameKey":"item.barcode",
+         "path":"$.items[*].barcode",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.callnumber",
+         "displayNameKey":"item.callNumber",
+         "path":"$.item[*].effectiveCallNumberComponents.callNumber",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.callnumberprefix",
+         "displayNameKey":"item.callNumberPrefix",
+         "path":"$.item[*].effectiveCallNumberComponents.prefix",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.callnumbersuffix",
+         "displayNameKey":"item.callNumberSuffix",
+         "path":"$.item[*].effectiveCallNumberComponents.suffix",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.callnumbertype",
+         "displayNameKey":"item.callNumberType",
+         "path":"$.item[*].effectiveCallNumberComponents.typeId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.chronology",
+         "displayNameKey":"item.chronology",
+         "path":"$.items[*].chronology",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.copynumber",
+         "displayNameKey":"item.copyNumber",
+         "path":"$.items[*].copyNumber",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.descriptionofpieces",
+         "displayNameKey":"item.descriptionOfPieces",
+         "path":"$.items[*].descriptionOfPieces",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.default",
+         "displayNameKey":"item.electronic.access.linkText.default",
+         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.no.display.constant.generated",
+         "displayNameKey":"item.electronic.access.linkText",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.no.information.provided",
+         "displayNameKey":"item.electronic.access.linkText",
+         "referenceDataValue":"No information provided",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.related.resource",
+         "displayNameKey":"item.electronic.access.linkText",
+         "referenceDataValue":"Related resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.resource",
+         "displayNameKey":"item.electronic.access.linkText",
+         "referenceDataValue":"Resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.linktext.version.of.resource",
+         "displayNameKey":"item.electronic.access.linkText",
+         "referenceDataValue":"Version of resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.default",
+         "displayNameKey":"item.electronic.access.materialsSpecification.default",
+         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.no.display.constant.generated",
+         "displayNameKey":"item.electronic.access.materialsSpecification",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.no.information.provided",
+         "displayNameKey":"item.electronic.access.materialsSpecification",
+         "referenceDataValue":"No information provided",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.related.resource",
+         "displayNameKey":"item.electronic.access.materialsSpecification",
+         "referenceDataValue":"Related resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.resource",
+         "displayNameKey":"item.electronic.access.materialsSpecification",
+         "referenceDataValue":"Resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.materialsspecification.version.of.resource",
+         "displayNameKey":"item.electronic.access.materialsSpecification",
+         "referenceDataValue":"Version of resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.default",
+         "displayNameKey":"item.electronic.access.publicNote.default",
+         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.no.display.constant.generated",
+         "displayNameKey":"item.electronic.access.publicNote",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.no.information.provided",
+         "displayNameKey":"item.electronic.access.publicNote",
+         "referenceDataValue":"No information provided",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.related.resource",
+         "displayNameKey":"item.electronic.access.publicNote",
+         "referenceDataValue":"Related resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.resource",
+         "displayNameKey":"item.electronic.access.publicNote",
+         "referenceDataValue":"Resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.publicnote.version.of.resource",
+         "displayNameKey":"item.electronic.access.publicNote",
+         "referenceDataValue":"Version of resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.default",
+         "displayNameKey":"item.electronic.access.uri.default",
+         "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.no.display.constant.generated",
+         "displayNameKey":"item.electronic.access.uri",
+         "referenceDataValue":"No display constant generated",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.no.information.provided",
+         "displayNameKey":"item.electronic.access.uri",
+         "referenceDataValue":"No information provided",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.related.resource",
+         "displayNameKey":"item.electronic.access.uri",
+         "referenceDataValue":"Related resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.resource",
+         "displayNameKey":"item.electronic.access.uri",
+         "referenceDataValue":"Resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.electronic.access.uri.version.of.resource",
+         "displayNameKey":"item.electronic.access.uri",
+         "referenceDataValue":"Version of resource",
+         "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.enumeration",
+         "displayNameKey":"item.enumeration",
+         "path":"$.items[*].enumeration",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.holdingsrecordid",
+         "displayNameKey":"item.holdingsRecordId",
+         "path":"$.items[*].holdingsRecordId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.hrid",
+         "displayNameKey":"item.hrid",
+         "path":"$.item.hrid",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.id",
+         "displayNameKey":"item.id",
+         "path":"$.item.id",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.itemnotetypeid.action.note",
+         "displayNameKey":"item.itemNoteTypeId",
+         "referenceDataValue":"Action note",
+         "path":"$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.itemnotetypeid.binding",
+         "displayNameKey":"item.itemNoteTypeId",
+         "referenceDataValue":"Binding",
+         "path":"$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && (!(@.staffOnly) || @.staffOnly == false))].note",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.itemnotetypeid.staffonly.action.note",
+         "displayNameKey":"item.itemNoteTypeId.staffOnly",
+         "referenceDataValue":"Action note",
+         "path":"$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.itemnotetypeid.staffonly.binding",
+         "displayNameKey":"item.itemNoteTypeId.staffOnly",
+         "referenceDataValue":"Binding",
+         "path":"$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && ((@.staffOnly) && @.staffOnly == true))].note",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.materialtypeid.book",
+         "displayNameKey":"item.materialTypeId",
+         "referenceDataValue":"book",
+         "path":"$.items[*].materialTypeId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.materialtypeid.dvd",
+         "displayNameKey":"item.materialTypeId",
+         "referenceDataValue":"dvd",
+         "path":"$.items[*].materialTypeId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.metadata.createdbyuserid",
+         "displayNameKey":"item.metadata.createdByUserId",
+         "path":"$.item.metadata.createdByUserId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.metadata.createddate",
+         "displayNameKey":"item.metadata.createdDate",
+         "path":"$.item.metadata.createdDate",
+         "recordType":"ITEM",
+         "metadataParameters":{
+            "datesOfPublication":"$.instance.publication[*].dateOfPublication",
+            "languages":"$.instance.languages"
+         }
+      },
+      {
+         "fieldId":"item.metadata.updatedbyuserid",
+         "displayNameKey":"item.metadata.updatedByUserId",
+         "path":"$.item.metadata.updatedByUserId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.metadata.updateddate",
+         "displayNameKey":"item.metadata.updatedDate",
+         "path":"$.item.metadata.updatedDate",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.numberofpieces",
+         "displayNameKey":"item.numberOfPieces",
+         "path":"$.items[*].numberOfPieces",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.permanentloantypeid.can.circulate",
+         "displayNameKey":"item.permanentLoanTypeId",
+         "referenceDataValue":"Can circulate",
+         "path":"$.items[*].permanentLoanTypeId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.permanentloantypeid.reading.room",
+         "displayNameKey":"item.permanentLoanTypeId",
+         "referenceDataValue":"Reading room",
+         "path":"$.items[*].permanentLoanTypeId",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.status",
+         "displayNameKey":"item.status",
+         "path":"$.items[*].status.name",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.volume",
+         "displayNameKey":"item.volume",
+         "path":"$.items[*].volume",
+         "recordType":"ITEM"
+      },
+      {
+         "fieldId":"item.yearcaption",
+         "displayNameKey":"item.yearCaption",
+         "path":"$.items[*].yearCaption",
+         "recordType":"ITEM"
       }
-    },
-    {
-      "fieldId":"holdings.metadata.updatedbyuserid",
-      "displayNameKey":"holdings.metadata.updatedByUserId",
-      "path":"$.holdings.metadata.updatedByUserId",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId":"holdings.metadata.updateddate",
-      "displayNameKey":"holdings.metadata.updatedDate",
-      "path":"$.holdings.metadata.updatedDate",
-      "recordType":"HOLDINGS"
-    },
-    {
-      "fieldId": "holdings.holdingnotetypeid.copy.note",
-      "displayNameKey": "holdings.holdingNoteTypeId",
-      "referenceDataValue": "Copy note",
-      "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && @.staffOnly == 'false')].holdingsNoteTypeId",
-      "recordType": "HOLDINGS"
-    },
-    {
-      "fieldId": "holdings.holdingnotetypeid.staffonly.copy.note",
-      "displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
-      "referenceDataValue": "Copy note",
-      "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='c4407cc7-d79f-4609-95bd-1cefb2e2b5c5' && @.staffOnly == 'true')].holdingsNoteTypeId",
-      "recordType": "HOLDINGS"
-    },
-    {
-      "fieldId": "holdings.holdingnotetypeid.electronic.bookplate",
-      "displayNameKey": "holdings.holdingNoteTypeId",
-      "referenceDataValue": "Electronic bookplate",
-      "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && @.staffOnly == 'false')].holdingsNoteTypeId",
-      "recordType": "HOLDINGS"
-    },
-    {
-      "fieldId": "holdings.holdingnotetypeid.staffonly.electronic.bookplate",
-      "displayNameKey": "holdings.holdingNoteTypeId.staffOnly",
-      "referenceDataValue": "Electronic bookplate",
-      "path": "$.holdings[*].notes[?(@.holdingsNoteTypeId=='88914775-f677-4759-b57b-1a33b90b24e0' && @.staffOnly == 'true')].holdingsNoteTypeId",
-      "recordType": "HOLDINGS"
-    },
-    {
-      "fieldId":"instance.alternativetitletypename.cover.title",
-      "displayNameKey":"instance.alternativeTitleTypeName",
-      "referenceDataValue":"Cover title",
-      "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='5c364ce4-c8fd-4891-a28d-bb91c9bcdbfb')].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.alternativetitletypename.running.title",
-      "displayNameKey":"instance.alternativeTitleTypeName",
-      "referenceDataValue":"Running title",
-      "path":"$.instance.alternativeTitles[?(@.alternativeTitleTypeId=='09964ad1-7aed-49b8-8223-a4c105e3ef87')].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.corporate.name",
-      "displayNameKey":"instance.contributorName",
-      "referenceDataValue":"Corporate name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && (!(@.primary) || @.primary == false))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.meeting.name",
-      "displayNameKey":"instance.contributorName",
-      "referenceDataValue":"Meeting name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && (!(@.primary) || @.primary == false))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.personal.name",
-      "displayNameKey":"instance.contributorName",
-      "referenceDataValue":"Personal name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && (!(@.primary) || @.primary == false))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.primary.corporate.name",
-      "displayNameKey":"instance.contributorName.primary",
-      "referenceDataValue":"Corporate name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='2e48e713-17f3-4c13-a9f8-23845bb210aa' && ((@.primary) && @.primary == true))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.primary.meeting.name",
-      "displayNameKey":"instance.contributorName.primary",
-      "referenceDataValue":"Meeting name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='e8b311a6-3b21-43f2-a269-dd9310cb2d0a' && ((@.primary) && @.primary == true))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.contributorname.primary.personal.name",
-      "displayNameKey":"instance.contributorName.primary",
-      "referenceDataValue":"Personal name",
-      "path":"$.instance.contributors[?(@.contributorNameTypeId=='2b94c631-fca9-4892-a730-03ee529ffe2a' && ((@.primary) && @.primary == true))].name",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.editions",
-      "displayNameKey":"instance.editions",
-      "path":"$.instance.editions",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext.no.display.constant.generated",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext.no.information.provided",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "referenceDataValue":"No information provided",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext.related.resource",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "referenceDataValue":"Related resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext.resource",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "referenceDataValue":"Resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.linktext.version.of.resource",
-      "displayNameKey":"instance.electronic.access.linkText",
-      "referenceDataValue":"Version of resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification.no.display.constant.generated",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification.no.information.provided",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "referenceDataValue":"No information provided",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification.related.resource",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "referenceDataValue":"Related resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification.resource",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "referenceDataValue":"Resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.materialsspecification.version.of.resource",
-      "displayNameKey":"instance.electronic.access.materialsSpecification",
-      "referenceDataValue":"Version of resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote.no.display.constant.generated",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote.no.information.provided",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "referenceDataValue":"No information provided",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote.related.resource",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "referenceDataValue":"Related resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote.resource",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "referenceDataValue":"Resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.publicnote.version.of.resource",
-      "displayNameKey":"instance.electronic.access.publicNote",
-      "referenceDataValue":"Version of resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri",
-      "displayNameKey":"instance.electronic.access.uri",
-      "path":"$.instance.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri.no.display.constant.generated",
-      "displayNameKey":"instance.electronic.access.uri",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri.no.information.provided",
-      "displayNameKey":"instance.electronic.access.uri",
-      "referenceDataValue":"No information provided",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri.related.resource",
-      "displayNameKey":"instance.electronic.access.uri",
-      "referenceDataValue":"Related resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri.resource",
-      "displayNameKey":"instance.electronic.access.uri",
-      "referenceDataValue":"Resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.electronic.access.uri.version.of.resource",
-      "displayNameKey":"instance.electronic.access.uri",
-      "referenceDataValue":"Version of resource",
-      "path":"$.instance.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.hrid",
-      "displayNameKey":"instance.hrid",
-      "path":"$.instance.hrid",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.id",
-      "displayNameKey":"instance.id",
-      "path":"$.instance.id",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.gpo.item.number",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"GPO item number",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='351ebc1c-3aae-4825-8765-c6d50dbf011f')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.isbn",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"ISBN",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='8261054f-be78-422d-bd51-4ed9f33c3422')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.issn",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"ISSN",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='913300b2-03ed-469a-8179-c1092c991227')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.lccn",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"LCCN",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='c858e4f2-2b6b-4385-842b-60732ee14abb')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.oclc",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"OCLC",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.identifiers.system.control.number",
-      "displayNameKey":"instance.identifiers",
-      "referenceDataValue":"System control number",
-      "path":"$.instance.identifiers[?(@.identifierTypeId=='7e591197-f335-4afb-bc6d-a6d76ca3bace')].value",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.instancetypeid.other",
-      "displayNameKey":"instance.instanceTypeId",
-      "referenceDataValue":"other",
-      "path":"$.instance[?(@.instanceTypeId=='a2c91e87-6bab-44d6-8adb-1fd02481fc4f')].instanceTypeId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.instancetypeid.text",
-      "displayNameKey":"instance.instanceTypeId",
-      "referenceDataValue":"text",
-      "path":"$.instance[?(@.instanceTypeId=='6312d172-f0cf-40f6-b27d-9fa8feaf332f')].instanceTypeId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.languages",
-      "displayNameKey":"instance.languages",
-      "path":"$.instance.languages",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.metadata.createdbyuserid",
-      "displayNameKey":"instance.metadata.createdByUserId",
-      "path":"$.instance.metadata.createdByUserId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.metadata.createddate",
-      "displayNameKey":"instance.metadata.createdDate",
-      "path":"$.instance.metadata.createdDate",
-      "recordType":"INSTANCE",
-      "metadataParameters":{
-        "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-        "languages":"$.instance.languages"
-      }
-    },
-    {
-      "fieldId":"instance.metadata.updatedbyuserid",
-      "displayNameKey":"instance.metadata.updatedByUserId",
-      "path":"$.instance.metadata.updatedByUserId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.metadata.updateddate",
-      "displayNameKey":"instance.metadata.updatedDate",
-      "path":"$.instance.metadata.updatedDate",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.modeofissuanceid.multipart.monograph",
-      "displayNameKey":"instance.modeOfIssuanceId",
-      "referenceDataValue":"multipart monograph",
-      "path":"$.instance[?(@.modeOfIssuanceId=='f5cc2ab6-bb92-4cab-b83f-5a3d09261a41')].modeOfIssuanceId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.modeofissuanceid.single.unit",
-      "displayNameKey":"instance.modeOfIssuanceId",
-      "referenceDataValue":"single unit",
-      "path":"$.instance[?(@.modeOfIssuanceId=='9d18a02f-5897-4c31-9106-c9abb5c7ae8b')].modeOfIssuanceId",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.source",
-      "displayNameKey":"instance.source",
-      "path":"$.instance.source",
-      "recordType":"INSTANCE"
-    },
-    {
-      "fieldId":"instance.subjects",
-      "displayNameKey":"instance.subjects",
-      "path":"$.instance.subjects",
-      "recordType":"INSTANCE"
-    },
-    {
-    "fieldId" : "instance.title",
-    "displayNameKey" : "instance.title",
-    "path" : "$.instance.title",
-    "recordType" : "INSTANCE"
-    },
-    {
-      "fieldId":"item.barcode",
-      "displayNameKey":"item.barcode",
-      "path":"$.items[*].barcode",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.callnumber",
-      "displayNameKey":"item.callNumber",
-      "path":"$.item[*].effectiveCallNumberComponents.callNumber",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.callnumberprefix",
-      "displayNameKey":"item.callNumberPrefix",
-      "path":"$.item[*].effectiveCallNumberComponents.prefix",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.callnumbersuffix",
-      "displayNameKey":"item.callNumberSuffix",
-      "path":"$.item[*].effectiveCallNumberComponents.suffix",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.callnumbertype",
-      "displayNameKey":"item.callNumberType",
-      "path":"$.item[*].effectiveCallNumberComponents.typeId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.chronology",
-      "displayNameKey":"item.chronology",
-      "path":"$.items[*].chronology",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.copynumber",
-      "displayNameKey":"item.copyNumber",
-      "path":"$.items[*].copyNumber",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.descriptionofpieces",
-      "displayNameKey":"item.descriptionOfPieces",
-      "path":"$.items[*].descriptionOfPieces",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext",
-      "displayNameKey":"item.electronic.access.linkText",
-      "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext.no.display.constant.generated",
-      "displayNameKey":"item.electronic.access.linkText",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext.no.information.provided",
-      "displayNameKey":"item.electronic.access.linkText",
-      "referenceDataValue":"No information provided",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext.related.resource",
-      "displayNameKey":"item.electronic.access.linkText",
-      "referenceDataValue":"Related resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext.resource",
-      "displayNameKey":"item.electronic.access.linkText",
-      "referenceDataValue":"Resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.linktext.version.of.resource",
-      "displayNameKey":"item.electronic.access.linkText",
-      "referenceDataValue":"Version of resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].linkText",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification.no.display.constant.generated",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification.no.information.provided",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "referenceDataValue":"No information provided",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification.related.resource",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "referenceDataValue":"Related resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification.resource",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "referenceDataValue":"Resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.materialsspecification.version.of.resource",
-      "displayNameKey":"item.electronic.access.materialsSpecification",
-      "referenceDataValue":"Version of resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].materialsSpecification",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote.no.display.constant.generated",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote.no.information.provided",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "referenceDataValue":"No information provided",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote.related.resource",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "referenceDataValue":"Related resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote.resource",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "referenceDataValue":"Resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.publicnote.version.of.resource",
-      "displayNameKey":"item.electronic.access.publicNote",
-      "referenceDataValue":"Version of resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].publicNote",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri",
-      "displayNameKey":"item.electronic.access.uri",
-      "path":"$.item.electronicAccess[?(!(@.relationshipId) || @.relationshipId == null)].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri.no.display.constant.generated",
-      "displayNameKey":"item.electronic.access.uri",
-      "referenceDataValue":"No display constant generated",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='ef03d582-219c-4221-8635-bc92f1107021')].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri.no.information.provided",
-      "displayNameKey":"item.electronic.access.uri",
-      "referenceDataValue":"No information provided",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f50c90c9-bae0-4add-9cd0-db9092dbc9dd')].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri.related.resource",
-      "displayNameKey":"item.electronic.access.uri",
-      "referenceDataValue":"Related resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='5bfe1b7b-f151-4501-8cfa-23b321d5cd1e')].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri.resource",
-      "displayNameKey":"item.electronic.access.uri",
-      "referenceDataValue":"Resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='f5d0068e-6272-458e-8a81-b85e7b9a14aa')].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.electronic.access.uri.version.of.resource",
-      "displayNameKey":"item.electronic.access.uri",
-      "referenceDataValue":"Version of resource",
-      "path":"$.item.electronicAccess[?(@.relationshipId=='3b430592-2e09-4b48-9a0c-0636d66b9fb3')].uri",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.enumeration",
-      "displayNameKey":"item.enumeration",
-      "path":"$.items[*].enumeration",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.holdingsrecordid",
-      "displayNameKey":"item.holdingsRecordId",
-      "path":"$.items[*].holdingsRecordId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.hrid",
-      "displayNameKey":"item.hrid",
-      "path":"$.item.hrid",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.id",
-      "displayNameKey":"item.id",
-      "path":"$.item.id",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.materialtypeid.book",
-      "displayNameKey":"item.materialTypeId",
-      "referenceDataValue":"book",
-      "path":"$.items[*].materialTypeId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.materialtypeid.dvd",
-      "displayNameKey":"item.materialTypeId",
-      "referenceDataValue":"dvd",
-      "path":"$.items[*].materialTypeId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.metadata.createdbyuserid",
-      "displayNameKey":"item.metadata.createdByUserId",
-      "path":"$.item.metadata.createdByUserId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.metadata.createddate",
-      "displayNameKey":"item.metadata.createdDate",
-      "path":"$.item.metadata.createdDate",
-      "recordType":"ITEM",
-      "metadataParameters":{
-        "datesOfPublication":"$.instance.publication[*].dateOfPublication",
-        "languages":"$.instance.languages"
-      }
-    },
-    {
-      "fieldId":"item.metadata.updatedbyuserid",
-      "displayNameKey":"item.metadata.updatedByUserId",
-      "path":"$.item.metadata.updatedByUserId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.metadata.updateddate",
-      "displayNameKey":"item.metadata.updatedDate",
-      "path":"$.item.metadata.updatedDate",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.numberofpieces",
-      "displayNameKey":"item.numberOfPieces",
-      "path":"$.items[*].numberOfPieces",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.permanentloantypeid.can.circulate",
-      "displayNameKey":"item.permanentLoanTypeId",
-      "referenceDataValue":"Can circulate",
-      "path":"$.items[*].permanentLoanTypeId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.permanentloantypeid.reading.room",
-      "displayNameKey":"item.permanentLoanTypeId",
-      "referenceDataValue":"Reading room",
-      "path":"$.items[*].permanentLoanTypeId",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.status",
-      "displayNameKey":"item.status",
-      "path":"$.items[*].status.name",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.volume",
-      "displayNameKey":"item.volume",
-      "path":"$.items[*].volume",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId":"item.yearcaption",
-      "displayNameKey":"item.yearCaption",
-      "path":"$.items[*].yearCaption",
-      "recordType":"ITEM"
-    },
-    {
-      "fieldId": "item.itemnotetypeid.binding",
-      "displayNameKey": "item.itemNoteTypeId",
-      "referenceDataValue": "Binding",
-      "path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && @.staffOnly == 'false')].itemNoteTypeId",
-      "recordType": "ITEM"
-    },
-    {
-      "fieldId": "item.itemnotetypeid.staffonly.binding",
-      "displayNameKey": "item.itemNoteTypeId.staffOnly",
-      "referenceDataValue": "Binding",
-      "path": "$.item[*].notes[?(@.itemNoteTypeId=='87c450be-2033-41fb-80ba-dd2409883681' && @.staffOnly == 'true')].itemNoteTypeId",
-      "recordType": "ITEM"
-    },
-    {
-      "fieldId": "item.itemnotetypeid.action.note",
-      "displayNameKey": "item.itemNoteTypeId",
-      "referenceDataValue": "Action note",
-      "path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && @.staffOnly == 'false')].itemNoteTypeId",
-      "recordType": "ITEM"
-    },
-    {
-      "fieldId": "item.itemnotetypeid.staffonly.action.note",
-      "displayNameKey": "item.itemNoteTypeId.staffOnly",
-      "referenceDataValue": "Action note",
-      "path": "$.item[*].notes[?(@.itemNoteTypeId=='0e40884c-3523-4c6d-8187-d578e3d2794e' && @.staffOnly == 'true')].itemNoteTypeId",
-      "recordType": "ITEM"
-    }
-  ],
-  "totalRecords":135
+   ],
+   "totalRecords":144
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-271

## Purpose
For proper translations, the UI needs a way to differentiate default values with values that they have to replace with reference data.This PR addresses that

## Approach
Add default at the end of default field names

Additional:
- This also has a fix for the comment which was missed in https://github.com/folio-org/mod-data-export/pull/146#discussion_r474689945


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
