### PR TITLE
Fix after removing old location function in gererate-marc-utils

### DIFF
--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -165,8 +165,8 @@ class MappingServiceUnitTest {
     List<VariableField> appendedMarcRecords = mappingService.mapFields(srsRecord, mappingProfile, jobExecutionId, params);
     // then
     //all transformations provided in the mapping profile must be mapped
-    Assert.assertEquals(11, appendedMarcRecords.stream().map(vf -> vf.getTag()).collect(Collectors.toSet()).size());
-    Assert.assertEquals(20, appendedMarcRecords.size());
+    Assert.assertEquals(8, appendedMarcRecords.stream().map(vf -> vf.getTag()).collect(Collectors.toSet()).size());
+    Assert.assertEquals(17, appendedMarcRecords.size());
   }
 
   @Test
@@ -226,13 +226,10 @@ class MappingServiceUnitTest {
     transformations.add(createTransformations(CALLNUMBER_SUFFIX_FIELD_ID, CALLNUMBER_SUFFIX_FIELD_PATH, "902  $a", HOLDINGS));
     transformations.add(createTransformations(ELECTRONIC_ACCESS_LINKTEXT_FIELD_ID, HOLDINGS_ELECTRONIC_ACCESS_LINK_TEXT_PATH, "903  $a", HOLDINGS));
     transformations.add(createTransformations(ELECTRONIC_ACCESS_URI_FIELD_ID, HOLDINGS_ELECTRONIC_ACCESS_URI_PATH, "90412$a", HOLDINGS));
-    transformations.add(createTransformations(PERMANENT_LOCATION_FIELD_ID, PERMANENT_LOCATION_PATH, "905  $a", HOLDINGS));
-    transformations.add(createTransformations(TEMPORARY_LOCATION_FIELD_ID, TEMPORARY_LOCATION_PATH, "906  $b", HOLDINGS));
     transformations.add(createTransformations(EFFECTIVECALLNUMBER_CALL_NUMBER_FIELD_ID, ITEMS_EFFECTIVE_CALL_NUMBER_PATH, "907  $a", ITEM));
     transformations.add(createTransformations(ELECTRONIC_ACCESS_LINKTEXT_FIELD_ID, ITEMS_ELECTRONIC_ACCESS_LINK_TEXT_PATH, "908  $a", ITEM));
     transformations.add(createTransformations(ELECTRONIC_ACCESS_URI_FIELD_ID, ITEMS_ELECTRONIC_ACCESS_URI_PATH, "9091 $a", ITEM));
     transformations.add(createTransformations(MATERIALTYPE_FIELD_ID, MATERIAL_TYPE_ID_PATH, "910  $a", ITEM));
-    transformations.add(createTransformations(EFFECTIVE_LOCATION_FIELD_ID, EFFECTIVE_LOCATION_PATH, "911  $a", ITEM));
     return transformations;
   }
 

--- a/src/test/java/org/folio/service/mapping/convertor/SrsRecordConvertorServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/convertor/SrsRecordConvertorServiceUnitTest.java
@@ -166,8 +166,6 @@ class SrsRecordConvertorServiceUnitTest {
     transformations.add(createTransformations("callNumberSuffix", "$.holdings[*].callNumberSuffix", "902  $a", HOLDINGS));
     transformations.add(createTransformations("electronicAccess.linkText", "$.holdings[*].electronicAccess[*].linkText", "903  $a", HOLDINGS));
     transformations.add(createTransformations("electronicAccess.uri", "$.holdings[*].electronicAccess[*].uri", "90412$a", HOLDINGS));
-    transformations.add(createTransformations("permanentLocationId", "$.holdings[*].permanentLocationId", "905  $a", HOLDINGS));
-    transformations.add(createTransformations("temporaryLocationId", "$.holdings[*].temporaryLocationId", "906  $b", HOLDINGS));
     transformations.add(createTransformations("effectiveCallNumberComponents.callNumber", "$.items[*].effectiveCallNumberComponents.callNumber", "907  $a", ITEM));
     transformations.add(createTransformations("electronicAccess.linkText", "$.items[*].electronicAccess[*].linkText", "908  $a", ITEM));
     transformations.add(createTransformations("electronicAccess.uri", "$.items[*].electronicAccess[*].uri", "9091 $a", ITEM));

--- a/src/test/resources/mapping/expected_marc_record_with_only_holdings_and_items.json
+++ b/src/test/resources/mapping/expected_marc_record_with_only_holdings_and_items.json
@@ -71,28 +71,6 @@
       }
     },
     {
-      "905": {
-        "subfields": [
-          {
-            "a": "Miller General Stacks"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
-      "906": {
-        "subfields": [
-          {
-            "b": "Special Reading Room"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
       "907": {
         "subfields": [
           {
@@ -218,17 +196,6 @@
         "subfields": [
           {
             "a": "dvd"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
-      "911": {
-        "subfields": [
-          {
-            "a": "Special Reading Room"
           }
         ],
         "ind1": " ",

--- a/src/test/resources/mapping/expected_marc_record_with_only_holdings_and_items_and_instances.json
+++ b/src/test/resources/mapping/expected_marc_record_with_only_holdings_and_items_and_instances.json
@@ -91,28 +91,6 @@
       }
     },
     {
-      "905": {
-        "subfields": [
-          {
-            "a": "Miller General Stacks"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
-      "906": {
-        "subfields": [
-          {
-            "b": "Special Reading Room"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
       "907": {
         "subfields": [
           {
@@ -238,17 +216,6 @@
         "subfields": [
           {
             "a": "dvd"
-          }
-        ],
-        "ind1": " ",
-        "ind2": " "
-      }
-    },
-    {
-      "911": {
-        "subfields": [
-          {
-            "a": "Special Reading Room"
           }
         ],
         "ind1": " ",


### PR DESCRIPTION
Temporary fix to remove usage of the old location transformations as far as the old location translation function was removed from generate-marc-utils library. Removed location fields from unit test, nevertheless they will be returned in the scope of full PR for MDEXP-252 with a new convention of naming and so on.