### PR TITLE
MDEXP-281-POC Export records using CQL

### DIFF
--- a/ramls/dataExport-file-definition.raml
+++ b/ramls/dataExport-file-definition.raml
@@ -82,7 +82,7 @@ traits:
               application/octet-stream:
           queryParameters:
             isCQLFile:
-              description: is true, then export by using CQL query, otherwise - by file with uuids
+              description: if true, then export by using CQL query, otherwise - by file with uuids
               type: boolean
               default: false
           responses:

--- a/ramls/dataExport-file-definition.raml
+++ b/ramls/dataExport-file-definition.raml
@@ -80,6 +80,11 @@ traits:
           description: Method to upload file
           body:
               application/octet-stream:
+          queryParameters:
+            isCQLFile:
+              description: is true, then export by using CQL query, otherwise - by file with uuids
+              type: boolean
+              default: false
           responses:
             200:
               body:

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -46,7 +46,6 @@ public class InventoryClient {
   private static final String QUERY_PATTERN_HOLDING = "instanceId==%s";
   private static final String QUERY_PATTERN_ITEM = "holdingsRecordId==%s";
   private static final String QUERY = "?(query=";
-  private static final String QUERY_VALUE = "(languages=\"eng\")";
   private static final int REFERENCE_DATA_LIMIT = 200;
   private static final int HOLDINGS_LIMIT = 1000;
 

--- a/src/main/java/org/folio/rest/impl/DataExportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImpl.java
@@ -50,10 +50,6 @@ public class DataExportImpl implements DataExport {
   private String tenantId;
 
   public DataExportImpl(Vertx vertx, String tenantId) {
-    System.setProperty("aws.region", "eu-west-2");
-    System.setProperty("aws.accessKeyId", "AKIAYI337D5FHL6T5Q5A");
-    System.setProperty("aws.secretKey", "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");
-    System.setProperty("bucket.name", "mod-export-1");
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
     this.tenantId = TenantTool.calculateTenantId(tenantId);
     this.inputDataManager = vertx.getOrCreateContext().get(InputDataManager.class.getName());

--- a/src/main/java/org/folio/rest/impl/DataExportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImpl.java
@@ -50,6 +50,10 @@ public class DataExportImpl implements DataExport {
   private String tenantId;
 
   public DataExportImpl(Vertx vertx, String tenantId) {
+    System.setProperty("aws.region", "eu-west-2");
+    System.setProperty("aws.accessKeyId", "AKIAYI337D5FHL6T5Q5A");
+    System.setProperty("aws.secretKey", "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");
+    System.setProperty("bucket.name", "mod-export-1");
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
     this.tenantId = TenantTool.calculateTenantId(tenantId);
     this.inputDataManager = vertx.getOrCreateContext().get(InputDataManager.class.getName());

--- a/src/main/java/org/folio/service/file/storage/FileStorage.java
+++ b/src/main/java/org/folio/service/file/storage/FileStorage.java
@@ -3,6 +3,8 @@ package org.folio.service.file.storage;
 import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.FileDefinition;
 
+import java.util.List;
+
 /**
  * File storage service, service to save files.
  */
@@ -12,6 +14,11 @@ public interface FileStorage {
    * Saves bytes to the storage asynchronously
    */
   Future<FileDefinition> saveFileDataAsync(byte[] data, FileDefinition fileDefinition);
+
+  /**
+   * Saves bytes to the storage asynchronously
+   */
+  Future<FileDefinition> saveFileDataAsyncCQL(List<String> uuids, FileDefinition fileDefinition);
 
   /**
    * Save bytes to the storage in blocking manner

--- a/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
+++ b/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
@@ -5,19 +5,24 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.file.FileSystem;
+import org.folio.clients.InventoryClient;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -29,6 +34,8 @@ public class LocalFileSystemStorage implements FileStorage {
 
   private WorkerExecutor workerExecutor;
   private FileSystem fileSystem;
+  @Autowired
+  private InventoryClient inventoryClient;
 
 
   public LocalFileSystemStorage(@Autowired Vertx vertx) {
@@ -42,6 +49,22 @@ public class LocalFileSystemStorage implements FileStorage {
     workerExecutor.<Void>executeBlocking(blockingFuture -> {
       try {
         saveFileData(data, fileDefinition);
+      } catch (Exception e) {
+        LOGGER.error("Error during save data to the local system's storage. FileId: {}", fileDefinition.getId(), e);
+        promise.fail(e);
+      }
+      promise.complete(fileDefinition);
+    }, null);
+    return promise.future();
+  }
+
+  @Override
+  public Future<FileDefinition> saveFileDataAsyncCQL(List<String> uuids, FileDefinition fileDefinition) {
+    Promise<FileDefinition> promise = Promise.promise();
+    workerExecutor.<Void>executeBlocking(blockingFuture -> {
+      try {
+        String collect = uuids.stream().collect(Collectors.joining(System.lineSeparator()));
+        saveFileData(collect.getBytes(StandardCharsets.UTF_8.name()), fileDefinition);
       } catch (Exception e) {
         LOGGER.error("Error during save data to the local system's storage. FileId: {}", fileDefinition.getId(), e);
         promise.fail(e);

--- a/src/main/java/org/folio/service/file/upload/FileUploadService.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadService.java
@@ -3,6 +3,7 @@ package org.folio.service.file.upload;
 import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.service.file.storage.FileStorage;
+import org.folio.util.OkapiConnectionParams;
 
 /**
  * File upload service. Provides lifecycle methods for file uploading functionality.
@@ -22,10 +23,17 @@ public interface FileUploadService {
    *
    * @param fileDefinition {@link FileDefinition}
    * @param data           array of file bytes
-   * @param tenantId       tenant id
    * @return {@link FileDefinition}
    */
   Future<FileDefinition> saveFileChunk(FileDefinition fileDefinition, byte[] data, String tenantId);
+
+  /**
+   * Saves given file data to the {@link FileStorage}
+   *
+   * @param fileDefinition {@link FileDefinition}
+   * @return {@link FileDefinition}
+   */
+  Future<FileDefinition> saveUUIDsByCQL(FileDefinition fileDefinition, String query, OkapiConnectionParams params);
 
   /**
    * Completes uploading for the given {@link FileDefinition}

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -67,7 +67,7 @@ public class FileUploadServiceImpl implements FileUploadService {
     List<String> list = new ArrayList<>();
     if (instancesUUIDs.isPresent()) {
       JsonArray array = instancesUUIDs.get().getJsonArray("ids");
-      // possibly a good place to use parralel stream. Also, worth thinking to add some additional field to file definition, for example 'format'
+      // Worth thinking to add some additional field to file definition, for example 'format'
       // with possible values: csv || cql. Then we can create a job execution with progress here, set total to the array size, and while export,
       // avoid count of lines in file for calculate total field if format is cql.
       array.stream().forEach(var -> {

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -67,6 +67,7 @@ public class FileUploadServiceImpl implements FileUploadService {
     List<String> list = new ArrayList<>();
     if (instancesUUIDs.isPresent()) {
       JsonArray array = instancesUUIDs.get().getJsonArray("ids");
+      // possibly a good place to use parralel stream.
       array.stream().forEach(var -> {
         String a = ((JsonObject) var).getString("id");
         list.add(a);

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -1,16 +1,28 @@
 package org.folio.service.file.upload;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.folio.HttpStatus;
+import org.folio.clients.InventoryClient;
+import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobExecution;
-import org.folio.service.job.JobExecutionService;
-import org.folio.util.ErrorCode;
+import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.service.file.definition.FileDefinitionService;
 import org.folio.service.file.storage.FileStorage;
+import org.folio.service.job.JobExecutionService;
+import org.folio.util.ErrorCode;
+import org.folio.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.z3950.zing.cql.CQLParser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import static org.folio.rest.jaxrs.model.FileDefinition.Status.COMPLETED;
 import static org.folio.rest.jaxrs.model.FileDefinition.Status.ERROR;
@@ -22,6 +34,8 @@ public class FileUploadServiceImpl implements FileUploadService {
   private FileDefinitionService fileDefinitionService;
   private JobExecutionService jobExecutionService;
   private FileStorage fileStorage;
+  @Autowired
+  private InventoryClient inventoryClient;
 
   public FileUploadServiceImpl(@Autowired FileStorage fileStorage, @Autowired FileDefinitionService fileDefinitionService,
   @Autowired JobExecutionService jobExecutionService) {
@@ -47,6 +61,23 @@ public class FileUploadServiceImpl implements FileUploadService {
   }
 
   @Override
+  public Future<FileDefinition> saveUUIDsByCQL(FileDefinition fileDefinition, String query, OkapiConnectionParams params) {
+    Promise<FileDefinition> promise = Promise.promise();
+    Optional<JsonObject> instancesUUIDs = inventoryClient.getInstancesBulkUUIDs(query, params);
+    List<String> list = new ArrayList<>();
+    if (instancesUUIDs.isPresent()) {
+      JsonArray array = instancesUUIDs.get().getJsonArray("ids");
+      array.stream().forEach(var -> {
+        String a = ((JsonObject) var).getString("id");
+        list.add(a);
+      });
+    }
+    fileStorage.saveFileDataAsyncCQL(list, fileDefinition);
+    promise.complete(fileDefinition);
+    return  promise.future();
+  }
+
+  @Override
   public Future<FileDefinition> completeUploading(FileDefinition fileDefinition, String tenantId) {
     JobExecution jobExecution = new JobExecution();
     return jobExecutionService.save(jobExecution, tenantId).compose(savedJob ->
@@ -58,5 +89,6 @@ public class FileUploadServiceImpl implements FileUploadService {
     return fileDefinitionService.getById(fileDefinitionId, tenantId)
       .compose(fileDefinition -> fileDefinitionService.update(fileDefinition.withStatus(ERROR), tenantId));
   }
+
 
 }

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -67,7 +67,9 @@ public class FileUploadServiceImpl implements FileUploadService {
     List<String> list = new ArrayList<>();
     if (instancesUUIDs.isPresent()) {
       JsonArray array = instancesUUIDs.get().getJsonArray("ids");
-      // possibly a good place to use parralel stream.
+      // possibly a good place to use parralel stream. Also, worth thinking to add some additional field to file definition, for example 'format'
+      // with possible values: csv || cql. Then we can create a job execution with progress here, set total to the array size, and while export,
+      // avoid count of lines in file for calculate total field if format is cql.
       array.stream().forEach(var -> {
         String a = ((JsonObject) var).getString("id");
         list.add(a);

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -33,6 +33,7 @@ public class ExternalPathResolver {
   public static final String HOLDING = "holding";
   public static final String ITEM = "item";
   public static final String CONFIGURATIONS = "configurations";
+  public static final String INSTANCE_BULK_IDS = "bulkIds";
 
 
   private static final Map<String, String> EXTERNAL_APIS;
@@ -63,6 +64,7 @@ public class ExternalPathResolver {
     apis.put(ISSUANCE_MODES, "/modes-of-issuance");
     apis.put(HOLDING_NOTE_TYPES, "/holdings-note-types");
     apis.put(ITEM_NOTE_TYPES, "/item-note-types");
+    apis.put(INSTANCE_BULK_IDS, "/instance-bulk/ids");
 
     apis.put(USERS, "/users");
     apis.put(CONFIGURATIONS, "/configurations/entries");


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MDEXP-281

## Approach
The PR contains the example of changes at the backend side, to export records by CQL query. 
modified **/data-export/file-definitions/upload** endpoint, add  query parameter, that will come from UI, and determine 
is the file with UUIDs or with the CQL query.

Link to the wiki page: https://wiki.folio.org/display/FOLIJET/POC%3A+Export+records+using+CQL

