### PR TITLE
MDEXP-306: fixing migration scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>31.1.1</raml-module-builder.version>
+    <raml-module-builder.version>31.1.2</raml-module-builder.version>
     <vertx.version>3.9.0</vertx.version>
     <junit.version>5.4.2</junit.version>
     <rest-assured.version>3.3.0</rest-assured.version>

--- a/src/main/resources/templates/db_scripts/migration_scripts/add_last_updated_date_to_job.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/add_last_updated_date_to_job.sql
@@ -1,10 +1,10 @@
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{lastUpdatedDate}', to_jsonb(now()), true)
 WHERE jsonb -> 'lastUpdatedDate' IS NULL and
       jsonb -> 'completedDate' IS NULL;
 
 
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{lastUpdatedDate}', jsonb->'completedDate', true)
 WHERE jsonb -> 'lastUpdatedDate' IS NULL and
       jsonb -> 'completedDate' IS NOT NULL;

--- a/src/main/resources/templates/db_scripts/migration_scripts/rename_job_statuses.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/rename_job_statuses.sql
@@ -1,16 +1,16 @@
 -- update jobs with no exported records, set status 'FAIL'
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{status}', '"FAIL"')
-WHERE jsonb -> 'progress' ->> 'exported' = '0';
+WHERE jsonb -> 'progress' ->> 'exported' = '0' OR jsonb ->> 'status' = 'FAIL';
 
 -- update jobs with all the exported records, set status 'COMPLETED'
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{status}', '"COMPLETED"')
 WHERE jsonb -> 'progress' ->> 'failed' = '0' and
-	    jsonb -> 'progress' ->> 'exported' > '0';
+	    jsonb -> 'progress' ->> 'exported' > '0' and jsonb ->> 'status' = 'SUCCESS';
 
 -- update jobs with partially failed records, set status 'COMPLETED_WITH_ERRORS'
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{status}', '"COMPLETED_WITH_ERRORS"')
 WHERE jsonb -> 'progress' ->> 'failed' > '0' and
       jsonb -> 'progress' ->> 'exported' > '0';


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-306

## Purpose
Fix migration scripts to run on latest version
Fix them to run on any tenant

## Approach
- Add conditions to check if the job is in failed status to change to FAIL
- replace diku with generic name



## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
