### PR TITLE
MDEXP-267: fix jobExecution empty fileName and runBy when uploading an empty file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>2.22.2</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
           <systemPropertyVariables>

--- a/src/main/java/org/folio/service/job/JobExecutionService.java
+++ b/src/main/java/org/folio/service/job/JobExecutionService.java
@@ -1,12 +1,13 @@
 package org.folio.service.job;
 
 
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollection;
 import org.folio.rest.jaxrs.model.Progress;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 /**
  * JobExecution Service interface, contains logic for accessing jobs.
@@ -69,6 +70,17 @@ public interface JobExecutionService {
    * @param tenantId             tenant id
    */
   Future<JobExecution> prepareJobForExport(String id, FileDefinition fileExportDefinition, JsonObject user, int totalCount, boolean withProgress, String tenantId);
+
+  /**
+   * Updates {@link JobExecution} status with specified status && updates exported files && updates started and completed dates
+   *
+   * @param jobExecution         job execution
+   * @param fileExportDefinition definition of the file to export
+   * @param user                 user represented in json object
+   * @param withProgress         condition to add progress
+   * @param tenantId             tenant id
+   */
+  Future<JobExecution> prepareJobForFailedExport(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user, long totalCount, boolean withProgress, String tenantId);
 
   /**
    * Increment current value in {@link Progress} of {@link JobExecution}

--- a/src/main/java/org/folio/service/job/JobExecutionService.java
+++ b/src/main/java/org/folio/service/job/JobExecutionService.java
@@ -80,7 +80,7 @@ public interface JobExecutionService {
    * @param withProgress         condition to add progress
    * @param tenantId             tenant id
    */
-  Future<JobExecution> prepareJobForFailedExport(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user, long totalCount, boolean withProgress, String tenantId);
+  void prepareAndSaveJobForFailedExport(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user, int totalCount, boolean withProgress, String tenantId);
 
   /**
    * Increment current value in {@link Progress} of {@link JobExecution}

--- a/src/main/java/org/folio/service/job/JobExecutionServiceImpl.java
+++ b/src/main/java/org/folio/service/job/JobExecutionServiceImpl.java
@@ -1,11 +1,24 @@
 package org.folio.service.job;
 
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.folio.rest.jaxrs.model.JobExecution.Status.FAIL;
+import static org.folio.rest.jaxrs.model.JobExecution.Status.IN_PROGRESS;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.NotFoundException;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.dao.JobExecutionDao;
@@ -19,20 +32,11 @@ import org.folio.service.profiles.jobprofile.JobProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import javax.ws.rs.NotFoundException;
-import java.lang.invoke.MethodHandles;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static io.vertx.core.Future.failedFuture;
-import static io.vertx.core.Future.succeededFuture;
-import static java.lang.String.format;
-import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Implementation of the JobExecutionService, calls JobExecutionDao to access JobExecution metadata.
@@ -118,19 +122,19 @@ public class JobExecutionServiceImpl implements JobExecutionService {
   @Override
   public Future<JobExecution> prepareJobForExport(String id, FileDefinition fileExportDefinition, JsonObject user, int totalCount, boolean withProgress, String tenantId) {
     return getById(id, tenantId).compose(jobExecution -> {
-      prepareJobExecution(jobExecution, fileExportDefinition, IN_PROGRESS, user, totalCount, withProgress, tenantId);
+      prepareJobExecution(jobExecution, fileExportDefinition, IN_PROGRESS, user, totalCount, withProgress);
       return update(jobExecution, tenantId);
     });
   }
 
   @Override
-  public Future<JobExecution> prepareJobForFailedExport(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user, long totalCount, boolean withProgress, String tenantId) {
-    prepareJobExecution(jobExecution, fileExportDefinition, FAIL, user, totalCount, withProgress, tenantId);
+  public void prepareAndSaveJobForFailedExport(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user, int totalCount, boolean withProgress, String tenantId) {
+    prepareJobExecution(jobExecution, fileExportDefinition, FAIL, user, totalCount, withProgress);
     jobExecution.setCompletedDate(new Date());
-    return update(jobExecution, tenantId);
+    update(jobExecution, tenantId);
   }
 
-  private void prepareJobExecution(JobExecution jobExecution, FileDefinition fileExportDefinition, JobExecution.Status status, JsonObject user, long totalCount, boolean withProgress, String tenantId) {
+  private void prepareJobExecution(JobExecution jobExecution, FileDefinition fileExportDefinition, JobExecution.Status status, JsonObject user, int totalCount, boolean withProgress) {
     ExportedFile exportedFile = new ExportedFile()
       .withFileId(UUID.randomUUID().toString())
       .withFileName(fileExportDefinition.getFileName());
@@ -147,7 +151,7 @@ public class JobExecutionServiceImpl implements JobExecutionService {
       .withFirstName(personal.getString("firstName"))
       .withLastName(personal.getString("lastName")));
     if (withProgress) {
-        jobExecution.setProgress(new Progress().withTotal(totalCount));
+      jobExecution.setProgress(new Progress().withTotal(totalCount));
     }
   }
 
@@ -179,7 +183,7 @@ public class JobExecutionServiceImpl implements JobExecutionService {
         if (asyncResult.succeeded()) {
           List<JobExecution> jobExecutionList = asyncResult.result();
           jobExecutionList.forEach(jobExe -> {
-            jobExe.setStatus(JobExecution.Status.FAIL);
+            jobExe.setStatus(FAIL);
             jobExecutionDao.update(jobExe, tenantId);
           });
           jobExecutionPromise.complete();

--- a/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
+++ b/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
@@ -265,24 +265,6 @@ class InputDataManagerImpl implements InputDataManager {
     return !CQL.equals(requestFileDefinition.getUploadFormat());
   }
 
-  private void populateJobExecutionForEmptyFileUploaded(JobExecution jobExecution, FileDefinition fileExportDefinition, JsonObject user) {
-    Set<ExportedFile> exportedFiles = jobExecution.getExportedFiles();
-    ExportedFile exportedFile = new ExportedFile()
-      .withFileId(UUID.randomUUID().toString())
-      .withFileName(fileExportDefinition.getFileName());
-    exportedFiles.add(exportedFile);
-    jobExecution.setExportedFiles(exportedFiles);
-    jobExecution.setStatus(JobExecution.Status.FAIL);
-    jobExecution.setProgress(new Progress());
-    jobExecution.setCompletedDate(new Date());
-    if (user.containsKey("personal")) {
-      JsonObject personal = user.getJsonObject("personal");
-      jobExecution.setRunBy(new RunBy()
-        .withFirstName(personal.getString("firstName"))
-        .withLastName(personal.getString("lastName")));
-    }
-  }
-
   private InputDataContext getInputDataContext(String jobExecutionId) {
     return inputDataLocalMap.get(jobExecutionId);
   }

--- a/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
+++ b/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
@@ -5,22 +5,16 @@ import static java.util.Objects.nonNull;
 import static org.folio.rest.jaxrs.model.FileDefinition.UploadFormat.CQL;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.io.FilenameUtils;
 import org.folio.clients.UsersClient;
 import org.folio.rest.jaxrs.model.ExportRequest;
-import org.folio.rest.jaxrs.model.ExportedFile;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.MappingProfile;
-import org.folio.rest.jaxrs.model.Progress;
-import org.folio.rest.jaxrs.model.RunBy;
 import org.folio.service.file.definition.FileDefinitionService;
 import org.folio.service.file.reader.LocalStorageCsvSourceReader;
 import org.folio.service.file.reader.SourceReader;
@@ -125,7 +119,7 @@ class InputDataManagerImpl implements InputDataManager {
       errorLogService.saveGeneralError("Error while reading from input file with uuids or file is empty", jobExecutionId, tenantId);
       fileDefinitionService.save(fileExportDefinition.withStatus(FileDefinition.Status.ERROR), tenantId).onSuccess(savedFileDefinition -> {
         if (optionalUser.isPresent()) {
-          jobExecutionService.prepareJobForFailedExport(jobExecution, fileExportDefinition, optionalUser.get(), 0, true, tenantId);
+          jobExecutionService.prepareAndSaveJobForFailedExport(jobExecution, fileExportDefinition, optionalUser.get(), 0, true, tenantId);
         } else {
           ExportPayload exportPayload = createExportPayload(fileExportDefinition, mappingProfile, jobExecutionId, okapiConnectionParams);
           finalizeExport(exportPayload, ExportResult.failed(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -99,12 +99,11 @@ class DataExportTest extends RestVerticleTestBase {
     SpringContextUtil.autowireDependencies(this, vertxContext);
   }
 
-  @ParameterizedTest
-  @EnumSource(value = UploadFormat.class, names = {"CSV","CQL"})
-  void testExport_uploadingEmptyFile_FAILED_job(UploadFormat uploadFormat, VertxTestContext context) throws IOException {
+  @Test
+  void testExport_uploadingCsvEmptyFile_FAILED_job(VertxTestContext context) throws IOException {
     //given
     String tenantId = okapiConnectionParams.getTenantId();
-    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, uploadFormat, buildRequestSpecification(tenantId));
+    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, CSV, buildRequestSpecification(tenantId));
     // when
     ExportRequest exportRequest = buildExportRequest(uploadedFileDefinition);
     postRequest(JsonObject.mapFrom(exportRequest), EXPORT_URL);

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -120,6 +120,26 @@ class DataExportTest extends RestVerticleTestBase {
   }
 
   @Test
+  void testExport_uploadingCqlEmptyFile_FAILED_job(VertxTestContext context) throws IOException {
+    //given
+    String tenantId = okapiConnectionParams.getTenantId();
+    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, CQL, buildRequestSpecification(tenantId));
+    // when
+    ExportRequest exportRequest = buildExportRequest(uploadedFileDefinition);
+    postRequest(JsonObject.mapFrom(exportRequest), EXPORT_URL);
+    String jobExecutionId = uploadedFileDefinition.getJobExecutionId();
+    // then
+    vertx.setTimer(TIMER_DELAY, handler ->
+      jobExecutionDao.getById(jobExecutionId, tenantId).onSuccess(optionalJobExecution -> {
+        JobExecution jobExecution = optionalJobExecution.get();
+        context.verify(() -> {
+          assertJobExecution(jobExecution, FAIL, EXPORTED_RECORDS_EMPTY);
+          context.completeNow();
+        });
+      }));
+  }
+
+  @Test
   void testExportByCSV_UnderlyingSrsOnly_COMPLETED_job(VertxTestContext context) throws IOException {
     // given
     String tenantId = okapiConnectionParams.getTenantId();

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -97,12 +99,12 @@ class DataExportTest extends RestVerticleTestBase {
     SpringContextUtil.autowireDependencies(this, vertxContext);
   }
 
-
-  @Test
-  void testExport_uploadingEmptyCqlFile_FAILED_job(VertxTestContext context) throws IOException {
+  @ParameterizedTest
+  @EnumSource(value = UploadFormat.class, names = {"CSV","CQL"})
+  void testExport_uploadingEmptyFile_FAILED_job(UploadFormat uploadFormat, VertxTestContext context) throws IOException {
     //given
     String tenantId = okapiConnectionParams.getTenantId();
-    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, CQL, buildRequestSpecification(tenantId));
+    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, uploadFormat, buildRequestSpecification(tenantId));
     // when
     ExportRequest exportRequest = buildExportRequest(uploadedFileDefinition);
     postRequest(JsonObject.mapFrom(exportRequest), EXPORT_URL);
@@ -384,6 +386,8 @@ class DataExportTest extends RestVerticleTestBase {
     assertEquals(status, jobExecution.getStatus());
     assertNotNull(jobExecution.getCompletedDate());
     assertEquals(numberOfExportedRecords, jobExecution.getProgress().getExported());
+    assertNotNull(jobExecution.getExportedFiles().iterator().next().getFileName());
+    assertNotNull(jobExecution.getRunBy());
   }
 
   private void assertErrorLogs(ErrorLogCollection errorLogCollection, String jobExecutionId) {

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -100,26 +100,6 @@ class DataExportTest extends RestVerticleTestBase {
   }
 
   @Test
-  void testExport_uploadingCsvEmptyFile_FAILED_job(VertxTestContext context) throws IOException {
-    //given
-    String tenantId = okapiConnectionParams.getTenantId();
-    FileDefinition uploadedFileDefinition = uploadFile(EMPTY_FILE, CSV, buildRequestSpecification(tenantId));
-    // when
-    ExportRequest exportRequest = buildExportRequest(uploadedFileDefinition);
-    postRequest(JsonObject.mapFrom(exportRequest), EXPORT_URL);
-    String jobExecutionId = uploadedFileDefinition.getJobExecutionId();
-    // then
-    vertx.setTimer(TIMER_DELAY, handler ->
-      jobExecutionDao.getById(jobExecutionId, tenantId).onSuccess(optionalJobExecution -> {
-        JobExecution jobExecution = optionalJobExecution.get();
-        context.verify(() -> {
-          assertJobExecution(jobExecution, FAIL, EXPORTED_RECORDS_EMPTY);
-          context.completeNow();
-        });
-      }));
-  }
-
-  @Test
   void testExport_uploadingCqlEmptyFile_FAILED_job(VertxTestContext context) throws IOException {
     //given
     String tenantId = okapiConnectionParams.getTenantId();

--- a/src/test/java/org/folio/rest/impl/JobExecutionServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/JobExecutionServiceTest.java
@@ -63,36 +63,36 @@ class JobExecutionServiceTest extends RestVerticleTestBase {
       .body("totalRecords", is(0));
   }
 
-  @Test
-  void expireJobExecutions_return204_andChangeJobStatusToFail(VertxTestContext context) throws ParseException {
-    String dateString = "2020-09-15T11:02:00.847+0000";
-    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
-    Date date = dateFormat.parse(dateString);
-    JobExecution jobExecution = new JobExecution()
-      .withJobProfileId("6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a")
-      .withStatus(Status.IN_PROGRESS)
-      .withLastUpdatedDate(date);
-
-    jobExecutionService.save(jobExecution, TENANT_ID);
-
-    vertx.setTimer(3000L, handler -> {
-
-      RestAssured.given()
-        .spec(jsonRequestSpecification)
-        .when()
-        .post(EXPIRE_JOBS_URL)
-        .then()
-        .statusCode(HttpStatus.SC_NO_CONTENT);
-
-      vertx.setTimer(3000L, ar ->
-      jobExecutionService.getById(jobExecution.getId(), TENANT_ID)
-        .onComplete(asyncResult -> context.verify(() -> {
-          Assertions.assertTrue(asyncResult.succeeded());
-          Assertions.assertEquals(Status.FAIL, asyncResult.result().getStatus());
-          context.completeNow();
-        })));
-    });
-  }
+//  @Test
+//  void expireJobExecutions_return204_andChangeJobStatusToFail(VertxTestContext context) throws ParseException {
+//    String dateString = "2020-09-15T11:02:00.847+0000";
+//    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+//    Date date = dateFormat.parse(dateString);
+//    JobExecution jobExecution = new JobExecution()
+//      .withJobProfileId("6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a")
+//      .withStatus(Status.IN_PROGRESS)
+//      .withLastUpdatedDate(date);
+//
+//    jobExecutionService.save(jobExecution, TENANT_ID);
+//
+//    vertx.setTimer(3000L, handler -> {
+//
+//      RestAssured.given()
+//        .spec(jsonRequestSpecification)
+//        .when()
+//        .post(EXPIRE_JOBS_URL)
+//        .then()
+//        .statusCode(HttpStatus.SC_NO_CONTENT);
+//
+//      vertx.setTimer(3000L, ar ->
+//      jobExecutionService.getById(jobExecution.getId(), TENANT_ID)
+//        .onComplete(asyncResult -> context.verify(() -> {
+//          Assertions.assertTrue(asyncResult.succeeded());
+//          Assertions.assertEquals(Status.FAIL, asyncResult.result().getStatus());
+//          context.completeNow();
+//        })));
+//    });
+//  }
 
   @Test
   void deleteJobExecutions_return404_IfNoJobExecutionsWithGivenId() {

--- a/src/test/java/org/folio/rest/impl/JobExecutionServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/JobExecutionServiceTest.java
@@ -63,36 +63,36 @@ class JobExecutionServiceTest extends RestVerticleTestBase {
       .body("totalRecords", is(0));
   }
 
-//  @Test
-//  void expireJobExecutions_return204_andChangeJobStatusToFail(VertxTestContext context) throws ParseException {
-//    String dateString = "2020-09-15T11:02:00.847+0000";
-//    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
-//    Date date = dateFormat.parse(dateString);
-//    JobExecution jobExecution = new JobExecution()
-//      .withJobProfileId("6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a")
-//      .withStatus(Status.IN_PROGRESS)
-//      .withLastUpdatedDate(date);
-//
-//    jobExecutionService.save(jobExecution, TENANT_ID);
-//
-//    vertx.setTimer(3000L, handler -> {
-//
-//      RestAssured.given()
-//        .spec(jsonRequestSpecification)
-//        .when()
-//        .post(EXPIRE_JOBS_URL)
-//        .then()
-//        .statusCode(HttpStatus.SC_NO_CONTENT);
-//
-//      vertx.setTimer(3000L, ar ->
-//      jobExecutionService.getById(jobExecution.getId(), TENANT_ID)
-//        .onComplete(asyncResult -> context.verify(() -> {
-//          Assertions.assertTrue(asyncResult.succeeded());
-//          Assertions.assertEquals(Status.FAIL, asyncResult.result().getStatus());
-//          context.completeNow();
-//        })));
-//    });
-//  }
+  @Test
+  void expireJobExecutions_return204_andChangeJobStatusToFail(VertxTestContext context) throws ParseException {
+    String dateString = "2020-09-15T11:02:00.847+0000";
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+    Date date = dateFormat.parse(dateString);
+    JobExecution jobExecution = new JobExecution()
+      .withJobProfileId("6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a")
+      .withStatus(Status.IN_PROGRESS)
+      .withLastUpdatedDate(date);
+
+    jobExecutionService.save(jobExecution, TENANT_ID);
+
+    vertx.setTimer(3000L, handler -> {
+
+      RestAssured.given()
+        .spec(jsonRequestSpecification)
+        .when()
+        .post(EXPIRE_JOBS_URL)
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+
+      vertx.setTimer(3000L, ar ->
+      jobExecutionService.getById(jobExecution.getId(), TENANT_ID)
+        .onComplete(asyncResult -> context.verify(() -> {
+          Assertions.assertTrue(asyncResult.succeeded());
+          Assertions.assertEquals(Status.FAIL, asyncResult.result().getStatus());
+          context.completeNow();
+        })));
+    });
+  }
 
   @Test
   void deleteJobExecutions_return404_IfNoJobExecutionsWithGivenId() {

--- a/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
+++ b/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
@@ -1,14 +1,28 @@
 package org.folio.service.manager.input;
 
-import com.google.common.collect.Lists;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.shareddata.LocalMap;
-import io.vertx.core.shareddata.SharedData;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.assertj.core.util.Maps;
 import org.folio.clients.UsersClient;
 import org.folio.rest.jaxrs.model.ExportRequest;
@@ -40,29 +54,16 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.support.AbstractApplicationContext;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import com.google.common.collect.Lists;
 
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.SharedData;
 
 @RunWith(MockitoJUnitRunner.class)
 class InputDataManagerUnitTest {
@@ -168,14 +169,14 @@ class InputDataManagerUnitTest {
     //given
     when(sourceReader.hasNext()).thenReturn(false);
     when(fileDefinitionService.save(any(FileDefinition.class), eq(TENANT_ID))).thenReturn(Future.succeededFuture(new FileDefinition()));
-    doCallRealMethod().when(jobExecutionService).prepareJobForFailedExport(any(), any(FileDefinition.class), eq(USER), eq(Long.valueOf(0)), eq(true),  eq(TENANT_ID));
+    doCallRealMethod().when(jobExecutionService).prepareAndSaveJobForFailedExport(any(), any(FileDefinition.class), eq(USER), eq(0), eq(true), eq(TENANT_ID));
     //when
     inputDataManager.initBlocking(exportRequestJson, JsonObject.mapFrom(requestFileDefinition), JsonObject.mapFrom(mappingProfile), JsonObject.mapFrom(jobExecution), requestParams);
 
     //then
     verify(sourceReader).close();
     verify(fileDefinitionService).save(fileExportDefinitionCaptor.capture(), eq(TENANT_ID));
-    verify(jobExecutionService).prepareJobForFailedExport(jobExecutionCaptor.capture(), any(FileDefinition.class), eq(USER), eq(Long.valueOf(0)), eq(true),  eq(TENANT_ID));
+    verify(jobExecutionService).prepareAndSaveJobForFailedExport(jobExecutionCaptor.capture(), any(FileDefinition.class), eq(USER), eq(0), eq(true), eq(TENANT_ID));
     assertNotNull(jobExecutionCaptor.getValue().getCompletedDate());
     FileDefinition fileDefinition = fileExportDefinitionCaptor.getValue();
     assertThat(fileDefinition.getStatus(), equalTo(FileDefinition.Status.ERROR));


### PR DESCRIPTION
## Purpose
Add fileName and runBy fields to jobExecution when uploading an empty file for borh csv and cql upload formats.
Jira: https://issues.folio.org/browse/MDEXP-267
![results](https://user-images.githubusercontent.com/60663044/96609424-2e723b80-1303-11eb-9276-54bbd7a6afaa.PNG)
