### PR TITLE
MDEXP-276 Restrict creating a mapping profile to supported fields only

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataExportImplMappingProfilesImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplMappingProfilesImpl.java
@@ -5,17 +5,9 @@ import static java.lang.String.format;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.HttpStatus;
-import org.folio.processor.translations.Translation;
-import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.MappingProfile;
-import org.folio.rest.jaxrs.model.TransformationField;
-import org.folio.rest.jaxrs.model.TransformationFieldCollection;
-import org.folio.rest.jaxrs.model.Transformations;
 import org.folio.rest.jaxrs.resource.DataExportMappingProfiles;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.profiles.mappingprofile.MappingProfileService;
@@ -25,11 +17,8 @@ import org.folio.util.ExceptionToResponseMapper;
 import org.folio.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.swing.text.html.Option;
 import javax.ws.rs.core.Response;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class DataExportImplMappingProfilesImpl implements DataExportMappingProfiles {
   private final String tenantId;

--- a/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileService.java
+++ b/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileService.java
@@ -53,5 +53,14 @@ public interface MappingProfileService {
    */
   Future<MappingProfile> getById(String mappingProfileId, String tenantId);
 
+  /**
+   * Validates {@link MappingProfile}
+   *
+   * @param mappingProfile {@link MappingProfile} to validate
+   * @param params {@link OkapiConnectionParams} okapi headers and connection parameters
+   * @return future with {@link Void}
+   */
+  Future<Void> validate(MappingProfile mappingProfile, OkapiConnectionParams params);
+
 
 }

--- a/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileServiceImpl.java
+++ b/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileServiceImpl.java
@@ -119,29 +119,28 @@ public class MappingProfileServiceImpl implements MappingProfileService {
   @Override
   public Future<Void> validate(MappingProfile mappingProfile, OkapiConnectionParams params) {
     if (CollectionUtils.isNotEmpty(mappingProfile.getTransformations())) {
-       return transformationFieldsService.getTransformationFields(params)
-        .compose(transformationFieldCollection -> {
-          List<TransformationField> transformationFields = transformationFieldCollection.getTransformationFields();
-          for (Transformations transformation : mappingProfile.getTransformations()) {
-            String fieldId = transformation.getFieldId();
-            if (StringUtils.isBlank(fieldId)) {
-              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, "Field id is missing for mapping profile transformation");
-            }
-            Optional<TransformationField> transformationFieldOptional = transformationFields.stream()
-              .filter(transformationField -> fieldId.equals(transformationField.getFieldId()))
-              .findFirst();
-            if (transformationFieldOptional.isEmpty()) {
-              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation doesn't exist by provided fieldId: %s", fieldId));
-            }
-            TransformationField transformationField = transformationFieldOptional.get();
-            TransformationField.RecordType expectedRecordType = transformationField.getRecordType();
-            if (Objects.isNull(transformation.getRecordType()) || !transformation.getRecordType().toString().equals(expectedRecordType.toString())) {
-              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation record type is missing or incorrect according to provided fieldId: %s, " +
-                "expected record type: %s", fieldId, expectedRecordType));
-            }
+      return transformationFieldsService.getTransformationFields(params).compose(transformationFieldCollection -> {
+        List<TransformationField> transformationFields = transformationFieldCollection.getTransformationFields();
+        for (Transformations transformation : mappingProfile.getTransformations()) {
+          String fieldId = transformation.getFieldId();
+          if (StringUtils.isBlank(fieldId)) {
+            throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, "Field id is missing for mapping profile transformation");
           }
-          return Future.succeededFuture();
-        });
+          Optional<TransformationField> transformationFieldOptional = transformationFields.stream()
+            .filter(transformationField -> fieldId.equals(transformationField.getFieldId()))
+            .findFirst();
+          if (transformationFieldOptional.isEmpty()) {
+            throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation doesn't exist by provided fieldId: %s", fieldId));
+          }
+          TransformationField transformationField = transformationFieldOptional.get();
+          TransformationField.RecordType expectedRecordType = transformationField.getRecordType();
+          if (Objects.isNull(transformation.getRecordType()) || !transformation.getRecordType().toString().equals(expectedRecordType.toString())) {
+            throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation record type is missing or incorrect according to provided fieldId: %s, " +
+              "expected record type: %s", fieldId, expectedRecordType));
+          }
+        }
+        return Future.succeededFuture();
+      });
     }
     return Future.succeededFuture();
   }

--- a/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileServiceImpl.java
+++ b/src/main/java/org/folio/service/profiles/mappingprofile/MappingProfileServiceImpl.java
@@ -1,26 +1,34 @@
 package org.folio.service.profiles.mappingprofile;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.clients.UsersClient;
 import org.folio.dao.MappingProfileDao;
 import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.MappingProfile;
 import org.folio.rest.jaxrs.model.MappingProfileCollection;
+import org.folio.rest.jaxrs.model.TransformationField;
+import org.folio.rest.jaxrs.model.Transformations;
+import org.folio.service.transformationfields.TransformationFieldsService;
 import org.folio.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.ws.rs.NotFoundException;
 import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
-
-import static io.vertx.core.Future.failedFuture;
-import static io.vertx.core.Future.succeededFuture;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
  * Implementation of the MappingProfileService, calls MappingProfileDao to access MappingProfile metadata.
@@ -34,6 +42,8 @@ public class MappingProfileServiceImpl implements MappingProfileService {
   private MappingProfileDao mappingProfileDao;
   @Autowired
   private UsersClient usersClient;
+  @Autowired
+  private TransformationFieldsService transformationFieldsService;
 
   @Override
   public Future<MappingProfileCollection> get(String query, int offset, int limit, String tenantId) {
@@ -105,4 +115,36 @@ public class MappingProfileServiceImpl implements MappingProfileService {
     }
     return mappingProfileDao.delete(mappingProfileId, tenantId);
   }
+
+  @Override
+  public Future<Void> validate(MappingProfile mappingProfile, OkapiConnectionParams params) {
+    if (CollectionUtils.isNotEmpty(mappingProfile.getTransformations())) {
+       return transformationFieldsService.getTransformationFields(params)
+        .compose(transformationFieldCollection -> {
+          List<TransformationField> transformationFields = transformationFieldCollection.getTransformationFields();
+          for (Transformations transformation : mappingProfile.getTransformations()) {
+            String fieldId = transformation.getFieldId();
+            if (StringUtils.isBlank(fieldId)) {
+              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, "Field id is missing for mapping profile transformation");
+            }
+            Optional<TransformationField> transformationFieldOptional = transformationFields.stream()
+              .filter(transformationField -> fieldId.equals(transformationField.getFieldId()))
+              .findFirst();
+            if (transformationFieldOptional.isEmpty()) {
+              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation doesn't exist by provided fieldId: %s", fieldId));
+            }
+            TransformationField transformationField = transformationFieldOptional.get();
+            TransformationField.RecordType expectedRecordType = transformationField.getRecordType();
+            if (Objects.isNull(transformation.getRecordType()) || !transformation.getRecordType().toString().equals(expectedRecordType.toString())) {
+              throw new ServiceException(HttpStatus.HTTP_UNPROCESSABLE_ENTITY, String.format("Transformation record type is missing or incorrect according to provided fieldId: %s, " +
+                "expected record type: %s", fieldId, expectedRecordType));
+            }
+          }
+          return Future.succeededFuture();
+        });
+    }
+    return Future.succeededFuture();
+  }
+
+
 }

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -427,7 +427,7 @@ class DataExportTest extends RestVerticleTestBase {
   private void validateExternalCallsForMappingProfileTransformations() {
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE).size());
     assertNull(MockServer.getServerRqRsData(HttpMethod.POST, ExternalPathResolver.SRS));
-    validateExternalCallsForReferenceData();
+    validateExternalCallsForReferenceDataForMappingProfileTransformations();
   }
 
   private void validateExternalCallsForReferenceData() {
@@ -442,6 +442,20 @@ class DataExportTest extends RestVerticleTestBase {
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_FORMATS).size());
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_TYPES).size());
     assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS).size());
+  }
+
+  private void validateExternalCallsForReferenceDataForMappingProfileTransformations() {
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.CONTENT_TERMS).size());
+    assertEquals(2, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.IDENTIFIER_TYPES).size());
+    assertEquals(2, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.CONTRIBUTOR_NAME_TYPES).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.LOCATIONS).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.LIBRARIES).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.CAMPUSES).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTITUTIONS).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.MATERIAL_TYPES).size());
+    assertEquals(1, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_FORMATS).size());
+    assertEquals(2, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.INSTANCE_TYPES).size());
+    assertEquals(2, MockServer.getServerRqRsData(HttpMethod.GET, ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS).size());
   }
 
   @Configuration

--- a/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
@@ -1,0 +1,72 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import org.apache.http.HttpStatus;
+import org.assertj.core.util.Lists;
+import org.folio.rest.jaxrs.model.MappingProfile;
+import org.folio.rest.jaxrs.model.RecordType;
+import org.folio.rest.jaxrs.model.Transformations;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@RunWith(VertxUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(VertxExtension.class)
+public class MappingProfileServiceTest extends RestVerticleTestBase {
+
+  @Test
+  void postMappingProfile_return422Status_whenTransformationFieldIdDoesntExist() {
+    MappingProfile mappingProfile = new MappingProfile()
+      .withName("mappingProfileName")
+      .withRecordTypes(Lists.newArrayList(RecordType.INSTANCE))
+      .withTransformations(Lists.newArrayList(new Transformations()
+        .withFieldId("missingFieldId")
+        .withRecordType(RecordType.INSTANCE)));
+    RestAssured.given()
+      .spec(jsonRequestSpecification)
+      .body(JsonObject.mapFrom(mappingProfile).encode())
+      .when()
+      .post(MAPPING_PROFILE_URL)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+
+  @Test
+  void postMappingProfile_return422Status_whenTransformationRecordTypeIncorrect() {
+    MappingProfile mappingProfile = new MappingProfile()
+      .withName("mappingProfileName")
+      .withRecordTypes(Lists.newArrayList(RecordType.HOLDINGS))
+      .withTransformations(Lists.newArrayList(new Transformations()
+        .withFieldId("instance.id")
+        .withRecordType(RecordType.HOLDINGS)));
+    RestAssured.given()
+      .spec(jsonRequestSpecification)
+      .body(JsonObject.mapFrom(mappingProfile).encode())
+      .when()
+      .post(MAPPING_PROFILE_URL)
+      .then()
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+  }
+
+  @Test
+  void postMappingProfile_return201Status() {
+    MappingProfile mappingProfile = new MappingProfile()
+      .withName("mappingProfileName")
+      .withRecordTypes(Lists.newArrayList(RecordType.INSTANCE))
+      .withTransformations(Lists.newArrayList(new Transformations()
+        .withFieldId("instance.id")
+        .withRecordType(RecordType.INSTANCE)));
+    RestAssured.given()
+      .spec(jsonRequestSpecification)
+      .body(JsonObject.mapFrom(mappingProfile).encode())
+      .when()
+      .post(MAPPING_PROFILE_URL)
+      .then()
+      .statusCode(HttpStatus.SC_CREATED);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
@@ -52,21 +52,4 @@ public class MappingProfileServiceTest extends RestVerticleTestBase {
       .then()
       .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
   }
-
-  @Test
-  void postMappingProfile_return201Status() {
-    MappingProfile mappingProfile = new MappingProfile()
-      .withName("mappingProfileName")
-      .withRecordTypes(Lists.newArrayList(RecordType.INSTANCE))
-      .withTransformations(Lists.newArrayList(new Transformations()
-        .withFieldId("instance.id")
-        .withRecordType(RecordType.INSTANCE)));
-    RestAssured.given()
-      .spec(jsonRequestSpecification)
-      .body(JsonObject.mapFrom(mappingProfile).encode())
-      .when()
-      .post(MAPPING_PROFILE_URL)
-      .then()
-      .statusCode(HttpStatus.SC_CREATED);
-  }
 }

--- a/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
+++ b/src/test/java/org/folio/rest/impl/MappingProfileServiceTest.java
@@ -17,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @RunWith(VertxUnitRunner.class)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(VertxExtension.class)
-public class MappingProfileServiceTest extends RestVerticleTestBase {
+class MappingProfileServiceTest extends RestVerticleTestBase {
 
   @Test
   void postMappingProfile_return422Status_whenTransformationFieldIdDoesntExist() {

--- a/src/test/java/org/folio/rest/impl/RestVerticleTestBase.java
+++ b/src/test/java/org/folio/rest/impl/RestVerticleTestBase.java
@@ -61,6 +61,7 @@ public abstract class RestVerticleTestBase {
   protected static final String JOB_EXECUTIONS_URL = "/data-export/job-executions";
   protected static final String EXPIRE_JOBS_URL = "/data-export/expire-jobs";
   protected static final String FIELD_NAMES_URL = "/data-export/transformation-fields";
+  protected static final String MAPPING_PROFILE_URL = "/data-export/mapping-profiles";
   protected static final String UPLOAD_URL = "/upload";
   protected static final String STORAGE_DIRECTORY_PATH = "./storage";
   protected static final String FILES_FOR_UPLOAD_DIRECTORY = "endToEndTestFiles/";

--- a/src/test/resources/endToEndTestFiles/mappingProfile.json
+++ b/src/test/resources/endToEndTestFiles/mappingProfile.json
@@ -3,13 +3,12 @@
   "name": "IT Mapping profile",
   "description": "Mapping profile for Testing Int Tests",
   "recordTypes": [
-    "HOLDINGS",
-    "ITEM"
+    "HOLDINGS"
   ],
   "outputFormat": "MARC",
   "transformations": [
     {
-      "fieldId": "callNumber",
+      "fieldId": "holdings.callnumber",
       "path": "$.holdings[*].callNumber",
       "transformation": "900ff$a",
       "enabled": true,

--- a/src/test/resources/profiles/mappingProfile.json
+++ b/src/test/resources/profiles/mappingProfile.json
@@ -8,8 +8,8 @@
   "outputFormat": "MARC",
   "transformations": [
     {
-      "fieldId": "electronicAccess.linkText",
-      "path": "$.holdings[*].items[*].electronicAccess[*].linkText",
+      "fieldId": "item.callnumber",
+      "path": "$.holdings[*].items[*].effectiveCallNumberComponents.callNumber",
       "transformation": "001",
       "enabled": true,
       "recordType": "ITEM"


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-276

##Description
Add validation for transformations during creation and updating mapping profile, match transformation fieldId with existing transformationFields

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [x] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [x] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
