### PR TITLE
MDEXP-305 Fix generated mrc files and directories are not being deleted

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -16,7 +16,7 @@ stages:
     steps:
       - applyAppConfig:
           catalogTemplate: p-rlq5p:concorde-helmcharts-mod-data-export
-          version: 0.1.26
+          version: 0.1.30
           answers:
             image.repository: docker.dev.folio.org/mod-data-export
             image.tag: concorde-${CICD_EXECUTION_SEQUENCE}

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -339,6 +339,17 @@
           ],
           "modulePermissions": [
           ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/data-export/clean-up-files",
+          "permissionsRequired": [
+            "data-export.clean-up-files.post"
+          ],
+          "modulePermissions": [
+          ]
         }
       ]
     },
@@ -375,6 +386,16 @@
           ],
           "unit": "hour",
           "delay": "6"
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/data-export/clean-up-files",
+          "modulePermissions": [
+          ],
+          "unit": "hour",
+          "delay": "1"
         }
       ]
     }
@@ -481,6 +502,11 @@
       "description": "Entry point to get error logs by job execution id"
     },
     {
+      "permissionName": "data-export.clean-up-files.post",
+      "displayName": "Data Export - call to clean up file definitions and related files",
+      "description": "Entry point to start clean up process of file definitions and related files"
+    },
+    {
       "permissionName": "data-export.all",
       "displayName": "Data Export - all permissions",
       "description": "Entire set of permissions needed to use the Data Export",
@@ -504,7 +530,8 @@
         "data-export.mapping-profiles.item.delete",
         "data-export.transformation-fields.collection.get",
         "data-export.expire-jobs.post",
-        "data-export.logs.collection.get"
+        "data-export.logs.collection.get",
+        "data-export.clean-up-files.post"
       ],
       "visible": false
     }

--- a/ramls/dataExport.raml
+++ b/ramls/dataExport.raml
@@ -144,3 +144,25 @@ resourceTypes:
             body:
               text/plain:
                 example: "Internal server error"
+  /clean-up-files:
+      displayName: Clean up FileDefinitions
+      description: API to start clean up mechanism of file definitions and related generated files
+      post:
+        is: [validate]
+        responses:
+          204:
+          400:
+            description: "Bad request"
+            body:
+              text/plain:
+                example: "Bad request"
+          422:
+            description: "Unprocessable Entity"
+            body:
+              application/json:
+                type: errors
+          500:
+            description: "Internal server error"
+            body:
+              text/plain:
+                example: "Internal server error"

--- a/src/main/java/org/folio/rest/impl/DataExportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImpl.java
@@ -119,7 +119,6 @@ public class DataExportImpl implements DataExport {
 
   @Override
   public void postDataExportCleanUpFiles(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    LOGGER.info("Requested call to clean up file definitions and related files");
     vertxContext.runOnContext(v -> storageCleanupService.cleanStorage(new OkapiConnectionParams(okapiHeaders))
       .map(PostDataExportCleanUpFilesResponse.respond204())
       .map(Response.class::cast)

--- a/src/main/java/org/folio/rest/impl/DataExportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImpl.java
@@ -119,6 +119,7 @@ public class DataExportImpl implements DataExport {
 
   @Override
   public void postDataExportCleanUpFiles(Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    LOGGER.info("Requested call to clean up file definitions and related files");
     vertxContext.runOnContext(v -> storageCleanupService.cleanStorage(new OkapiConnectionParams(okapiHeaders))
       .map(PostDataExportCleanUpFilesResponse.respond204())
       .map(Response.class::cast)

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -29,9 +29,7 @@ public class ModTenantAPI extends TenantAPI {
   public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers, Context context) {
     super.postTenant(entity, headers, asyncResult -> {
       if (asyncResult.failed()) {
-        if (Objects.nonNull(asyncResult.cause())) {
-          LOGGER.error("Post tenant is failed, cause: " + asyncResult.cause().getMessage());
-        }
+        LOGGER.error("Post tenant is failed, cause: " + asyncResult.cause().getMessage());
         handlers.handle(asyncResult);
       } else {
         LOGGER.info("Post tenant is complete successfully");

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -12,7 +12,6 @@ import org.folio.spring.SpringContextUtil;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
-import java.util.Objects;
 
 import static io.vertx.core.Future.succeededFuture;
 
@@ -29,10 +28,10 @@ public class ModTenantAPI extends TenantAPI {
   public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers, Context context) {
     super.postTenant(entity, headers, asyncResult -> {
       if (asyncResult.failed()) {
-        LOGGER.error("Post tenant is failed, cause: " + asyncResult.cause().getMessage());
+        LOGGER.error("Post tenant failed, cause: " + asyncResult.cause().getMessage());
         handlers.handle(asyncResult);
       } else {
-        LOGGER.info("Post tenant is complete successfully");
+        LOGGER.info("Post tenant is completed successfully");
         handlers.handle(succeededFuture(PostTenantResponse.respond201WithApplicationJson("Post tenant is complete")));
       }
     }, context);

--- a/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -8,23 +8,17 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.service.file.cleanup.StorageCleanupService;
 import org.folio.spring.SpringContextUtil;
-import org.folio.util.OkapiConnectionParams;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.vertx.core.Future.succeededFuture;
 
 public class ModTenantAPI extends TenantAPI {
   private static final Logger LOGGER = LoggerFactory.getLogger(ModTenantAPI.class);
 
-  private static final long DELAY_TIME_BETWEEN_CLEANUP_VALUE_MILLIS = 3600_000;
-
-  @Autowired
-  private StorageCleanupService storageCleanupService;
 
   public ModTenantAPI() { //NOSONAR
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
@@ -35,28 +29,15 @@ public class ModTenantAPI extends TenantAPI {
   public void postTenant(TenantAttributes entity, Map<String, String> headers, Handler<AsyncResult<Response>> handlers, Context context) {
     super.postTenant(entity, headers, asyncResult -> {
       if (asyncResult.failed()) {
+        if (Objects.nonNull(asyncResult.cause())) {
+          LOGGER.error("Post tenant is failed, cause: " + asyncResult.cause().getMessage());
+        }
         handlers.handle(asyncResult);
       } else {
-        initStorageCleanupService(headers, context);
+        LOGGER.info("Post tenant is complete successfully");
         handlers.handle(succeededFuture(PostTenantResponse.respond201WithApplicationJson("Post tenant is complete")));
       }
     }, context);
   }
 
-  private void initStorageCleanupService(Map<String, String> headers, Context context) {
-    Vertx vertx = context.owner();
-    OkapiConnectionParams params = new OkapiConnectionParams(headers);
-    vertx.setPeriodic(DELAY_TIME_BETWEEN_CLEANUP_VALUE_MILLIS, periodicHandler -> executeStorageCleanUpJob(vertx, params));
-  }
-
-  private void executeStorageCleanUpJob(Vertx vertx, OkapiConnectionParams params) {
-    vertx.<Void>executeBlocking(blockingCodeHandler -> storageCleanupService.cleanStorage(params),
-      cleanupAsyncResult -> {
-        if (cleanupAsyncResult.failed()) {
-          LOGGER.error("Error during cleaning file storage.", cleanupAsyncResult.cause().getMessage());
-        } else {
-          LOGGER.info("File storage was successfully cleaned of unused files");
-        }
-      });
-  }
 }

--- a/src/main/java/org/folio/service/file/cleanup/StorageCleanupServiceImpl.java
+++ b/src/main/java/org/folio/service/file/cleanup/StorageCleanupServiceImpl.java
@@ -16,6 +16,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+
 @Service
 public class StorageCleanupServiceImpl implements StorageCleanupService {
 
@@ -44,6 +46,7 @@ public class StorageCleanupServiceImpl implements StorageCleanupService {
   }
 
   private Future<CompositeFuture> deleteExpiredFilesAndRelatedFileDefinitions(List<FileDefinition> fileDefinitions, String tenantId) {
+    LOGGER.info(format("Start process of removing files and file definitions, number of file definitions to clean up: %s", fileDefinitions.size()));
     List<Future> deleteFilesFutures = fileDefinitions.stream()
       .map(fileDefinition -> deleteExpiredFileAndRelatedFileDefinition(fileDefinition, tenantId))
       .collect(Collectors.toList());

--- a/src/main/java/org/folio/service/file/cleanup/StorageCleanupServiceImpl.java
+++ b/src/main/java/org/folio/service/file/cleanup/StorageCleanupServiceImpl.java
@@ -46,7 +46,7 @@ public class StorageCleanupServiceImpl implements StorageCleanupService {
   }
 
   private Future<CompositeFuture> deleteExpiredFilesAndRelatedFileDefinitions(List<FileDefinition> fileDefinitions, String tenantId) {
-    LOGGER.info(format("Start process of removing files and file definitions, number of file definitions to clean up: %s", fileDefinitions.size()));
+    LOGGER.info("Start process of removing files and file definitions, number of file definitions to clean up: {}", fileDefinitions.size());
     List<Future> deleteFilesFutures = fileDefinitions.stream()
       .map(fileDefinition -> deleteExpiredFileAndRelatedFileDefinition(fileDefinition, tenantId))
       .collect(Collectors.toList());

--- a/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
@@ -1,13 +1,43 @@
 package org.folio.rest.impl;
 
 import io.restassured.RestAssured;
+import io.vertx.core.Context;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.FileDefinition;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.service.file.definition.FileDefinitionService;
+import org.folio.spring.SpringContextUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(VertxExtension.class)
 class DataExportCleanUpFilesTest extends RestVerticleTestBase {
+
+  @Autowired
+  private FileDefinitionService fileDefinitionService;
+
+  public DataExportCleanUpFilesTest() {
+    Context vertxContext = vertx.getOrCreateContext();
+    SpringContextUtil.init(vertxContext.owner(), vertxContext, DataExportTest.TestMock.class);
+    SpringContextUtil.autowireDependencies(this, vertxContext);
+  }
 
   @Test
   void shouldReturn_204Status_forHappyPathCleanUpFiles() {
@@ -17,6 +47,41 @@ class DataExportCleanUpFilesTest extends RestVerticleTestBase {
       .post(CLEAN_UP_FILES_URL)
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+
+  @Test
+  void shouldReturn_204Status_forHappyPathCleanUpFiles_andRemoveOldFileDefinitions(VertxTestContext context) throws ParseException {
+    // given
+    String fileDefinitionId = UUID.randomUUID().toString();
+    String dateString = "2020-09-15T11:02:00.847+0000";
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSZ");
+    Date date = dateFormat.parse(dateString);
+    FileDefinition fileDefinition = new FileDefinition()
+      .withMetadata(new Metadata()
+        .withUpdatedDate(date)
+        .withCreatedDate(date))
+      .withJobExecutionId(UUID.randomUUID().toString())
+      .withId(fileDefinitionId)
+      .withSourcePath("Path");
+    fileDefinitionService.save(fileDefinition, TENANT_ID);
+
+    vertx.setTimer(3000L, ar -> {
+      // when
+      RestAssured.given()
+        .spec(jsonRequestSpecification)
+        .when()
+        .post(CLEAN_UP_FILES_URL)
+        .then()
+        .statusCode(HttpStatus.SC_NO_CONTENT);
+
+      // then
+      fileDefinitionService.getById(fileDefinitionId, TENANT_ID)
+        .onComplete(asyncResult -> {
+          assertTrue(asyncResult.succeeded());
+          assertNull(asyncResult.result());
+          context.completeNow();
+        });
+    });
   }
 
 }

--- a/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(VertxUnitRunner.class)
 @ExtendWith(VertxExtension.class)
-@ExtendWith(MockitoExtension.class)
 class DataExportCleanUpFilesTest extends RestVerticleTestBase {
 
   @Autowired

--- a/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
@@ -1,0 +1,22 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+class DataExportCleanUpFilesTest extends RestVerticleTestBase {
+
+  @Test
+  void shouldReturn_204Status_forHappyPathCleanUpFiles() {
+    RestAssured.given()
+      .spec(jsonRequestSpecification)
+      .when()
+      .post(CLEAN_UP_FILES_URL)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportCleanUpFilesTest.java
@@ -67,11 +67,13 @@ class DataExportCleanUpFilesTest extends RestVerticleTestBase {
     fileDefinitionService.save(fileDefinition, TENANT_ID);
 
     vertx.setTimer(3000L, handler -> {
-
+      //when
       Response response = RestAssured.given()
         .spec(jsonRequestSpecification)
         .when()
         .post(CLEAN_UP_FILES_URL);
+
+      //then
       assertEquals(204, response.getStatusCode());
 
       vertx.setTimer(3000L, ar ->

--- a/src/test/java/org/folio/rest/impl/ErrorLogsTest.java
+++ b/src/test/java/org/folio/rest/impl/ErrorLogsTest.java
@@ -58,6 +58,7 @@ class ErrorLogsTest extends RestVerticleTestBase {
       .withJobExecutionId(jobExecutionId)
       .withLogLevel(ErrorLog.LogLevel.ERROR)
       .withId(logId)
+      .withAffectedRecord(instanceRecord)
       .withReason("Error reason");
     errorLogDao.save(errorLog, okapiConnectionParams.getTenantId());
 

--- a/src/test/java/org/folio/rest/impl/RestVerticleTestBase.java
+++ b/src/test/java/org/folio/rest/impl/RestVerticleTestBase.java
@@ -60,6 +60,7 @@ public abstract class RestVerticleTestBase {
   protected static final String ERROR_LOGS_SERVICE_URL = "/data-export/logs";
   protected static final String JOB_EXECUTIONS_URL = "/data-export/job-executions";
   protected static final String EXPIRE_JOBS_URL = "/data-export/expire-jobs";
+  protected static final String CLEAN_UP_FILES_URL = "/data-export/clean-up-files";
   protected static final String FIELD_NAMES_URL = "/data-export/transformation-fields";
   protected static final String MAPPING_PROFILE_URL = "/data-export/mapping-profiles";
   protected static final String UPLOAD_URL = "/upload";

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -164,6 +164,10 @@ public class StorageTestSuite {
   }
 
   @Nested
+  class ErrorLogsTestNested extends ErrorLogsTest {
+  }
+
+  @Nested
   class DataExportCleanUpFilesTestNested extends DataExportCleanUpFilesTest {
   }
 

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -163,7 +163,8 @@ public class StorageTestSuite {
   class TransformationFieldsServiceTestNested extends TransformationFieldsServiceTest {
   }
 
-
-
+  @Nested
+  class DataExportCleanUpFilesTestNested extends DataExportCleanUpFilesTest {
+  }
 
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MDEXP-305

## Approach
While investigating the issue, I saw that it is unreproducible on test/scratch envs. Investigated logs from bugfest-goldenroad, no logs about cleanup process - so the cleanup job is not running at all, or stuck. 
Decided to change mechanism of the cleanup process to provide a new endpoint, and use okapi timer to retrieve this API.
Also, it will give us the opportunity to manually start the cleanup process.
Updated rancher configs to helm configs with version: 0.1.30

