### PR TITLE
MDEXP-337 Fix correct job status when random uuids not in last batch

### DIFF
--- a/src/main/java/org/folio/service/file/reader/LocalStorageCsvSourceReader.java
+++ b/src/main/java/org/folio/service/file/reader/LocalStorageCsvSourceReader.java
@@ -25,6 +25,7 @@ import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.folio.rest.jaxrs.model.FileDefinition.UploadFormat.CQL;
+import static org.folio.util.ErrorCode.INVALID_UUID_FORMAT;
 
 @SuppressWarnings({"java:S2095"})
 public class LocalStorageCsvSourceReader implements SourceReader {
@@ -104,7 +105,7 @@ public class LocalStorageCsvSourceReader implements SourceReader {
         }
       }).count();
     if (CollectionUtils.isNotEmpty(invalidUUIDs)) {
-      errorLogService.saveGeneralError(format("Invalid UUID format: %s", String.join(COMMA, invalidUUIDs)), jobExecutionId, tenantId);
+      errorLogService.saveGeneralError(INVALID_UUID_FORMAT.getDescription() + String.join(COMMA, invalidUUIDs), jobExecutionId, tenantId);
     }
     return (int) count;
   }

--- a/src/main/java/org/folio/service/logs/ErrorLogService.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogService.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import org.folio.rest.jaxrs.model.ErrorLog;
 import org.folio.rest.jaxrs.model.ErrorLogCollection;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.util.ErrorCode;
 
 import java.util.Collection;
 import java.util.List;
@@ -93,5 +94,14 @@ public interface ErrorLogService {
    * @param tenantId              tenant id
    */
   void populateUUIDsNotFoundNumberErrorLog(String jobExecutionId, int numberOfNotFoundUUIDs, String tenantId);
+
+  /**
+   * If error log with description from error code is present - then true, otherwise - false
+   *
+   * @param errorCode             {@link ErrorCode}
+   * @param jobExecutionId        id of job execution
+   * @param tenantId              tenant id
+   */
+  Future<Boolean> isErrorsByReasonPresent(ErrorCode errorCode, String jobExecutionId, String tenantId);
 
 }

--- a/src/main/java/org/folio/service/logs/ErrorLogService.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogService.java
@@ -98,10 +98,10 @@ public interface ErrorLogService {
   /**
    * If error log with description from error code is present - then true, otherwise - false
    *
-   * @param errorCode             {@link ErrorCode}
+   * @param reasons               reasons using for querying the logs
    * @param jobExecutionId        id of job execution
    * @param tenantId              tenant id
    */
-  Future<Boolean> isErrorsByReasonPresent(ErrorCode errorCode, String jobExecutionId, String tenantId);
+  Future<Boolean> isErrorsByReasonPresent(List<String> reasons, String jobExecutionId, String tenantId);
 
 }

--- a/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
@@ -13,7 +13,6 @@ import org.folio.rest.jaxrs.model.AffectedRecord;
 import org.folio.rest.jaxrs.model.ErrorLog;
 import org.folio.rest.jaxrs.model.ErrorLogCollection;
 import org.folio.rest.persist.Criteria.Criterion;
-import org.folio.util.ErrorCode;
 import org.folio.util.HelperUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -33,7 +32,7 @@ import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.INSTANCE;
 import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.ITEM;
 import static org.folio.util.ErrorCode.SOME_RECORDS_FAILED;
 import static org.folio.util.ErrorCode.SOME_UUIDS_NOT_FOUND;
-import static org.folio.util.HelperUtils.getErrorLogCriterionByJobExecutionIdAndReason;
+import static org.folio.util.HelperUtils.getErrorLogCriterionByJobExecutionIdAndReasons;
 
 @Service
 public class ErrorLogServiceImpl implements ErrorLogService {
@@ -149,12 +148,9 @@ public class ErrorLogServiceImpl implements ErrorLogService {
 
   @Override
   public Future<Boolean> isErrorsByReasonPresent(
-      ErrorCode errorCode, String jobExecutionId, String tenantId) {
+      List<String> reasons, String jobExecutionId, String tenantId) {
     Promise<Boolean> promise = Promise.promise();
-    getByQuery(
-            getErrorLogCriterionByJobExecutionIdAndReason(
-                jobExecutionId, errorCode.getDescription()),
-            tenantId)
+    getByQuery(getErrorLogCriterionByJobExecutionIdAndReasons(jobExecutionId, reasons), tenantId)
         .onSuccess(errorLogList -> promise.complete(CollectionUtils.isNotEmpty(errorLogList)))
         .onFailure(ar -> promise.complete(false));
 

--- a/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
+++ b/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
@@ -171,12 +171,12 @@ class InputDataManagerImpl implements InputDataManager {
     if (status.equals(JobExecution.Status.COMPLETED)) {
       isErrorsRelatedToUUIDsPresent(jobExecutionId, tenantId)
           .onComplete(
-            isAnyErrorPresent -> {
-                if (isAnyErrorPresent.succeeded() && Boolean.TRUE.equals(isAnyErrorPresent.result())) {
+              isAnyErrorPresent -> {
+                if (isAnyErrorPresent.succeeded()
+                    && Boolean.TRUE.equals(isAnyErrorPresent.result())) {
                   exportResult.setStatus(COMPLETED_WITH_ERRORS);
                 }
-                jobExecutionService.updateJobStatusById(
-                    jobExecutionId, getJobExecutionStatus(exportResult), tenantId);
+                jobExecutionService.updateJobStatusById(jobExecutionId, getJobExecutionStatus(exportResult), tenantId);
                 updateFileDefinitionStatusByResult(fileExportDefinition, exportResult, tenantId);
               });
     } else {

--- a/src/main/java/org/folio/util/ErrorCode.java
+++ b/src/main/java/org/folio/util/ErrorCode.java
@@ -2,6 +2,9 @@ package org.folio.util;
 
 import org.folio.rest.jaxrs.model.Error;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum ErrorCode {
 
   GENERIC_ERROR_CODE("genericError", "Generic error"),
@@ -14,8 +17,8 @@ public enum ErrorCode {
   NOTHING_TO_EXPORT("nothingToExport", "No exported records, nothing to export"),
   SOME_RECORDS_FAILED("someRecordsFailed", "Export is completed with errors, some records have failed to export, number of failed records: "),
   SOME_UUIDS_NOT_FOUND("someUUIDsNotFound", "UUIDs not found in SRS or inventory: "),
+  INVALID_UUID_FORMAT("invalidUUIDFormat", "Invalid UUID format: "),
   INVALID_EXPORT_FILE_DEFINITION_ID("invalidExportFileDefinitionId", "Invalid export file definition id: ");
-
 
   private final String code;
   private final String description;
@@ -40,5 +43,13 @@ public enum ErrorCode {
 
   public Error toError() {
     return new Error().withCode(code).withMessage(description);
+  }
+
+  public static List<ErrorCode> reasonsAccordingToUUIDs() {
+    List<ErrorCode> errorCodesForUUIDs = new ArrayList<>();
+    errorCodesForUUIDs.add(SOME_UUIDS_NOT_FOUND);
+    errorCodesForUUIDs.add(SOME_RECORDS_FAILED);
+    errorCodesForUUIDs.add(INVALID_UUID_FORMAT);
+    return errorCodesForUUIDs;
   }
 }

--- a/src/main/java/org/folio/util/ErrorCode.java
+++ b/src/main/java/org/folio/util/ErrorCode.java
@@ -45,11 +45,11 @@ public enum ErrorCode {
     return new Error().withCode(code).withMessage(description);
   }
 
-  public static List<ErrorCode> reasonsAccordingToUUIDs() {
-    List<ErrorCode> errorCodesForUUIDs = new ArrayList<>();
-    errorCodesForUUIDs.add(SOME_UUIDS_NOT_FOUND);
-    errorCodesForUUIDs.add(SOME_RECORDS_FAILED);
-    errorCodesForUUIDs.add(INVALID_UUID_FORMAT);
+  public static List<String> reasonsAccordingToUUIDs() {
+    List<String> errorCodesForUUIDs = new ArrayList<>();
+    errorCodesForUUIDs.add(SOME_UUIDS_NOT_FOUND.getDescription());
+    errorCodesForUUIDs.add(SOME_RECORDS_FAILED.getDescription());
+    errorCodesForUUIDs.add(INVALID_UUID_FORMAT.getDescription());
     return errorCodesForUUIDs;
   }
 }

--- a/src/main/java/org/folio/util/HelperUtils.java
+++ b/src/main/java/org/folio/util/HelperUtils.java
@@ -8,6 +8,8 @@ import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.cql.CQLWrapper;
 
+import java.util.List;
+
 public class HelperUtils {
 
   private static final String JOB_EXECUTION_ID_FIELD = "'jobExecutionId'";
@@ -70,4 +72,21 @@ public class HelperUtils {
     return criterion;
   }
 
+  public static Criterion getErrorLogCriterionByJobExecutionIdAndReasons(
+      String jobExecutionId, List<String> reasons) {
+    Criterion criterion = new Criterion();
+    Criteria jobExecutionIdCriteria = new Criteria();
+    jobExecutionIdCriteria
+        .addField(JOB_EXECUTION_ID_FIELD)
+        .setOperation("=")
+        .setVal(jobExecutionId);
+    Criteria reasonCriteria = new Criteria();
+    reasonCriteria
+        .addField(REASON_FIELD)
+        .setOperation("SIMILAR TO")
+        .setVal("%" + String.join("|", reasons) + "%");
+    criterion.addCriterion(jobExecutionIdCriteria);
+    criterion.addCriterion(reasonCriteria);
+    return criterion;
+  }
 }

--- a/src/main/java/org/folio/util/HelperUtils.java
+++ b/src/main/java/org/folio/util/HelperUtils.java
@@ -86,7 +86,7 @@ public class HelperUtils {
         .setOperation("SIMILAR TO")
         .setVal(
             reasons.size() > 1
-                ? "%" + String.join("|", reasons) + "%"
+                ? "%(" + String.join("|", reasons) + ")%"
                 : "%" + reasons.get(0) + "%");
 
     criterion.addCriterion(jobExecutionIdCriteria);

--- a/src/main/java/org/folio/util/HelperUtils.java
+++ b/src/main/java/org/folio/util/HelperUtils.java
@@ -84,7 +84,11 @@ public class HelperUtils {
     reasonCriteria
         .addField(REASON_FIELD)
         .setOperation("SIMILAR TO")
-        .setVal("%" + String.join("|", reasons) + "%");
+        .setVal(
+            reasons.size() > 1
+                ? "%" + String.join("|", reasons) + "%"
+                : "%" + reasons.get(0) + "%");
+
     criterion.addCriterion(jobExecutionIdCriteria);
     criterion.addCriterion(reasonCriteria);
     return criterion;

--- a/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
+++ b/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
@@ -41,8 +41,10 @@ import org.folio.service.manager.export.ExportResult;
 import org.folio.util.ErrorCode;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -50,7 +52,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.support.AbstractApplicationContext;
 
@@ -65,7 +66,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.SharedData;
 
-@RunWith(MockitoJUnitRunner.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class InputDataManagerUnitTest {
 
   private static final int BATCH_SIZE = 2;
@@ -165,6 +166,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(1)
   void shouldNotInitExportSuccessfully_andSetStatusError_whenSourceStreamReaderEmpty() {
     //given
     when(sourceReader.hasNext()).thenReturn(false);
@@ -185,6 +187,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(2)
   void shouldInitInputDataContextBeforeExportData_whenSourceStreamNotEmpty() {
     //given
     when(sourceReader.hasNext()).thenReturn(true);
@@ -203,6 +206,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(3)
   void shouldCreate_andSaveFileExportDefinitionBeforeExport_whenSourceStreamNotEmpty() {
     //given
     when(sourceReader.hasNext()).thenReturn(true, false);
@@ -222,6 +226,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(4)
   void shouldInit_andExportData_whenSourceStreamHasOneChunk() {
     //given
     when(sourceReader.hasNext()).thenReturn(true, false);
@@ -247,6 +252,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(5)
   void shouldInit_andExportData_whenSourceStreamHasTwoChunks() {
     //given
     when(sourceReader.hasNext()).thenReturn(true, true);
@@ -272,6 +278,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(6)
   void shouldFinishExportWithErrors_whenProceedWithExportStatusError() {
     //given
     jobExecution.withProgress(new Progress());
@@ -296,6 +303,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(7)
   void shouldFinishExportSuccessfully_whenProceedWithExportStatusCompleted() {
     //given
     jobExecution.withProgress(new Progress());
@@ -305,6 +313,7 @@ class InputDataManagerUnitTest {
     when(inputDataLocalMap.containsKey(JOB_EXECUTION_ID)).thenReturn(true);
     when(inputDataLocalMap.get(JOB_EXECUTION_ID)).thenReturn(inputDataContext);
     when(inputDataContext.getSourceReader()).thenReturn(sourceReader);
+    when(errorLogService.isErrorsByReasonPresent(any(ErrorCode.class), anyString(), anyString())).thenReturn(Future.succeededFuture(false));
 
     //when
     inputDataManager.proceedBlocking(JsonObject.mapFrom(exportPayload), ExportResult.completed());
@@ -320,6 +329,34 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(8)
+  void shouldFinishExportWithErrors_whenProceedWithExportStatusCompleted_ButErrorLogsRelatesToTheUUIDsPresent() {
+    //given
+    jobExecution.withProgress(new Progress());
+    ExportPayload exportPayload = createExportPayload();
+    doCallRealMethod().when(jobExecutionService).updateJobStatusById(eq(JOB_EXECUTION_ID), eq(JobExecution.Status.COMPLETED_WITH_ERRORS), eq(TENANT_ID));
+    when(fileDefinitionService.update(fileExportDefinitionCaptor.capture(), eq(TENANT_ID))).thenReturn(Future.succeededFuture());
+    when(inputDataLocalMap.containsKey(JOB_EXECUTION_ID)).thenReturn(true);
+    when(inputDataLocalMap.get(JOB_EXECUTION_ID)).thenReturn(inputDataContext);
+    when(inputDataContext.getSourceReader()).thenReturn(sourceReader);
+    when(errorLogService.isErrorsByReasonPresent(any(ErrorCode.class), anyString(), anyString())).thenReturn(Future.succeededFuture(true));
+
+    //when
+    inputDataManager.proceedBlocking(JsonObject.mapFrom(exportPayload), ExportResult.completed());
+
+    //then
+      verify(jobExecutionService).update(jobExecution, TENANT_ID);
+      assertJobStatus(JobExecution.Status.COMPLETED_WITH_ERRORS);
+      assertNotNull(jobExecution.getCompletedDate());
+      FileDefinition.Status actualFileDefinitionStatus = fileExportDefinitionCaptor.getValue().getStatus();
+      assertThat(actualFileDefinitionStatus, equalTo(FileDefinition.Status.ERROR));
+      verify(sourceReader).close();
+      verify(inputDataLocalMap).remove(JOB_EXECUTION_ID);
+
+  }
+
+  @Test
+  @Order(9)
   void shouldFinishExportWithErrors_whenProceedWithExportStatusInProgress_andSourceStreamNull() {
     //given
     jobExecution.withProgress(new Progress());
@@ -343,6 +380,7 @@ class InputDataManagerUnitTest {
   }
 
   @Test
+  @Order(10)
   void shouldExportNextChunk_whenProceedWithExportStatusInProgress_andSourceStreamHasMoreChunksToExport() {
     //given
     ExportPayload exportPayload = createExportPayload();

--- a/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
+++ b/src/test/java/org/folio/service/manager/input/InputDataManagerUnitTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -313,7 +314,7 @@ class InputDataManagerUnitTest {
     when(inputDataLocalMap.containsKey(JOB_EXECUTION_ID)).thenReturn(true);
     when(inputDataLocalMap.get(JOB_EXECUTION_ID)).thenReturn(inputDataContext);
     when(inputDataContext.getSourceReader()).thenReturn(sourceReader);
-    when(errorLogService.isErrorsByReasonPresent(any(ErrorCode.class), anyString(), anyString())).thenReturn(Future.succeededFuture(false));
+    when(errorLogService.isErrorsByReasonPresent(anyList(), anyString(), anyString())).thenReturn(Future.succeededFuture(false));
 
     //when
     inputDataManager.proceedBlocking(JsonObject.mapFrom(exportPayload), ExportResult.completed());
@@ -339,7 +340,7 @@ class InputDataManagerUnitTest {
     when(inputDataLocalMap.containsKey(JOB_EXECUTION_ID)).thenReturn(true);
     when(inputDataLocalMap.get(JOB_EXECUTION_ID)).thenReturn(inputDataContext);
     when(inputDataContext.getSourceReader()).thenReturn(sourceReader);
-    when(errorLogService.isErrorsByReasonPresent(any(ErrorCode.class), anyString(), anyString())).thenReturn(Future.succeededFuture(true));
+    when(errorLogService.isErrorsByReasonPresent(anyList(), anyString(), anyString())).thenReturn(Future.succeededFuture(true));
 
     //when
     inputDataManager.proceedBlocking(JsonObject.mapFrom(exportPayload), ExportResult.completed());


### PR DESCRIPTION

## Purpose
When the random UUIDs not in the last batch - then job execution status always completed, instead of completed with errors.
Also, if the CSV file contains some text, not UUIDs, status should be completed with errors too.

## Approach
After calling finalize export, check if the error logs related to UUIDs are present, if yes - status completed with errors, if not - completed.
