### PR TITLE
MDEXP-262 Create a link to the inventory record if the export fails

### DIFF
--- a/ramls/samples/logs/recordLog.sample
+++ b/ramls/samples/logs/recordLog.sample
@@ -3,6 +3,7 @@
     "hrid": "200",
     "title": "Holdings record",
     "recordType": "HOLDINGS",
+    "inventoryRecordLink": "https://folio-testing.dev.folio.org/inventory/view/57c79d87-6510-4354-b212-96832fbf3fa1"
     "affectedRecords": [{
         "id": "e50c1f7f-1174-476c-88b7-a2e2fa8e657d",
         "hrid": "201",

--- a/ramls/schemas/logs/recordLog.json
+++ b/ramls/schemas/logs/recordLog.json
@@ -20,6 +20,10 @@
       "type": "object",
       "$ref": "../profiles/recordTypes.json"
     },
+    "inventoryRecordLink": {
+      "description": "Link to the affected inventory record",
+      "type": "string"
+    },
     "affectedRecords": {
       "description": "Affected record",
       "type": "array",

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,7 +1,17 @@
 package org.folio.config;
 
+import com.google.common.collect.ImmutableMap;
+import org.folio.service.logs.AffectedRecordBuilder;
+import org.folio.service.logs.AffectedRecordHoldingBuilder;
+import org.folio.service.logs.AffectedRecordInstanceBuilder;
+import org.folio.service.logs.AffectedRecordItemBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -10,4 +20,20 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.clients",
   "org.folio.rest.impl"})
 public class ApplicationConfig {
+  @Autowired
+  AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
+  @Autowired
+  AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
+  @Autowired
+  AffectedRecordItemBuilder affectedRecordItemBuilder;
+
+  @Bean
+  @Qualifier("affectedRecordBuilders")
+  public Map<String, AffectedRecordBuilder> getBuilders() {
+    return ImmutableMap.<String, AffectedRecordBuilder>builder()
+      .put(AffectedRecordInstanceBuilder.class.getName(), affectedRecordInstanceBuilder)
+      .put(AffectedRecordHoldingBuilder.class.getName(), affectedRecordHoldingBuilder)
+      .put(AffectedRecordItemBuilder.class.getName(), affectedRecordItemBuilder)
+      .build();
+  }
 }

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -20,16 +20,12 @@ import java.util.Map;
   "org.folio.clients",
   "org.folio.rest.impl"})
 public class ApplicationConfig {
-  @Autowired
-  AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
-  @Autowired
-  AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
-  @Autowired
-  AffectedRecordItemBuilder affectedRecordItemBuilder;
 
   @Bean
   @Qualifier("affectedRecordBuilders")
-  public Map<String, AffectedRecordBuilder> getBuilders() {
+  public Map<String, AffectedRecordBuilder> getBuilders(@Autowired AffectedRecordInstanceBuilder affectedRecordInstanceBuilder,
+                                                        @Autowired AffectedRecordHoldingBuilder affectedRecordHoldingBuilder,
+                                                        @Autowired AffectedRecordItemBuilder affectedRecordItemBuilder) {
     return ImmutableMap.<String, AffectedRecordBuilder>builder()
       .put(AffectedRecordInstanceBuilder.class.getName(), affectedRecordInstanceBuilder)
       .put(AffectedRecordHoldingBuilder.class.getName(), affectedRecordHoldingBuilder)

--- a/src/main/java/org/folio/service/logs/AffectedRecordBuilder.java
+++ b/src/main/java/org/folio/service/logs/AffectedRecordBuilder.java
@@ -16,7 +16,7 @@ public interface AffectedRecordBuilder {
    *
    * @param record                 record used for mapping process
    * @param jobExecutionId         job execution id
-   * @param recordId               id if the affected record
+   * @param recordId               id of the affected record
    * @param isLinkCreationRequired if true - link to the record will be created, otherwise not
    * @param params                 okapi connection parameters
    * @return {@link AffectedRecord}

--- a/src/main/java/org/folio/service/logs/AffectedRecordBuilder.java
+++ b/src/main/java/org/folio/service/logs/AffectedRecordBuilder.java
@@ -1,0 +1,42 @@
+package org.folio.service.logs;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.util.OkapiConnectionParams;
+
+/**
+ * AffectedRecordBuilder interface, contains logic for building affected records
+ */
+public interface AffectedRecordBuilder {
+
+
+  /**
+   * Returns AffectedRecord
+   *
+   * @param record                 record used for mapping process
+   * @param jobExecutionId         job execution id
+   * @param recordId               id if the affected record
+   * @param isLinkCreationRequired if true - link to the record will be created, otherwise not
+   * @param params                 okapi connection parameters
+   * @return {@link AffectedRecord}
+   */
+  AffectedRecord build(JsonObject record, String jobExecutionId, String recordId, boolean isLinkCreationRequired,
+                       OkapiConnectionParams params);
+
+  default AffectedRecord getAffectedRecordFromJson(
+    JsonObject recordJson, AffectedRecord.RecordType recordType) {
+    AffectedRecord record = new AffectedRecord().withRecordType(recordType);
+    if (StringUtils.isNotBlank(recordJson.getString("hrid"))) {
+      record.setHrid(recordJson.getString("hrid"));
+    }
+    if (StringUtils.isNotBlank(recordJson.getString("id"))) {
+      record.setId(recordJson.getString("id"));
+    }
+    if (StringUtils.isNotBlank(recordJson.getString("title"))) {
+      record.setTitle(recordJson.getString("title"));
+    }
+    return record;
+  }
+
+}

--- a/src/main/java/org/folio/service/logs/AffectedRecordHoldingBuilder.java
+++ b/src/main/java/org/folio/service/logs/AffectedRecordHoldingBuilder.java
@@ -1,0 +1,69 @@
+package org.folio.service.logs;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.HOLDINGS;
+
+@Component
+public class AffectedRecordHoldingBuilder implements AffectedRecordBuilder {
+
+  private static final String INSTANCE_ID = "instanceId";
+  private static final String ID_KEY = "id";
+  private static final String SLASH_SEPARATOR = "/";
+
+  @Autowired
+  private ConfigurationsClient configurationsClient;
+
+  @Autowired
+  private AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
+
+  @Override
+  public AffectedRecord build(JsonObject record, String jobExecutionId, String recordId, boolean isLinkCreationRequired,
+                              OkapiConnectionParams params) {
+    AffectedRecord holdingRecord = new AffectedRecord();
+    JsonArray holdings = record.getJsonArray(HOLDINGS.toString().toLowerCase());
+    Optional<JsonObject> holdingJson = getRecordFromArrayById(holdings, recordId);
+    if (holdingJson.isPresent()) {
+      holdingRecord = getAffectedRecordFromJson(holdingJson.get(), HOLDINGS);
+      String instanceId = holdingJson.get().getString(INSTANCE_ID);
+      holdingRecord.setAffectedRecords(Collections.singletonList(affectedRecordInstanceBuilder
+        .build(record, jobExecutionId, instanceId, false, params)));
+      if (isLinkCreationRequired) {
+        String linkToInventoryRecord = configurationsClient
+          .getInventoryRecordLink(getIdsUrlPart(recordId, instanceId), jobExecutionId, params);
+        if (StringUtils.isNotEmpty(linkToInventoryRecord)) {
+          holdingRecord.setInventoryRecordLink(linkToInventoryRecord);
+        }
+      }
+    }
+    return holdingRecord;
+  }
+
+  private String getIdsUrlPart(String holdingId, String instanceId) {
+    return StringUtils.joinWith(SLASH_SEPARATOR, instanceId, holdingId);
+  }
+
+  private Optional<JsonObject> getRecordFromArrayById(JsonArray records, String id) {
+    if (Objects.nonNull(records)) {
+      for (Object record : records) {
+        JsonObject recordJson = JsonObject.mapFrom(record);
+        if (id.equals(recordJson.getString(ID_KEY))) {
+          return Optional.of(recordJson);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/org/folio/service/logs/AffectedRecordInstanceBuilder.java
+++ b/src/main/java/org/folio/service/logs/AffectedRecordInstanceBuilder.java
@@ -1,0 +1,41 @@
+package org.folio.service.logs;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.INSTANCE;
+
+@Component
+public class AffectedRecordInstanceBuilder implements AffectedRecordBuilder {
+
+  @Autowired
+  ConfigurationsClient configurationsClient;
+
+  @Override
+  public AffectedRecord build(JsonObject record, String jobExecutionId, String recordId, boolean isLinkCreationRequired,
+                              OkapiConnectionParams params) {
+    JsonObject instance = record.getJsonObject(INSTANCE.toString().toLowerCase());
+    AffectedRecord instanceRecord = new AffectedRecord();
+    if (Objects.isNull(instance)) {
+      instanceRecord.setRecordType(INSTANCE);
+      instanceRecord.setId(recordId);
+    } else {
+      instanceRecord = getAffectedRecordFromJson(instance, INSTANCE);
+      if (isLinkCreationRequired) {
+        String linkToInventoryRecord = configurationsClient
+          .getInventoryRecordLink(recordId, jobExecutionId, params);
+        if (StringUtils.isNotEmpty(linkToInventoryRecord)) {
+          instanceRecord.setInventoryRecordLink(linkToInventoryRecord);
+        }
+      }
+    }
+    return instanceRecord;
+  }
+}

--- a/src/main/java/org/folio/service/logs/AffectedRecordItemBuilder.java
+++ b/src/main/java/org/folio/service/logs/AffectedRecordItemBuilder.java
@@ -1,0 +1,73 @@
+package org.folio.service.logs;
+
+import com.github.javaparser.utils.Pair;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.util.OkapiConnectionParams;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.ITEM;
+
+@Component
+public class AffectedRecordItemBuilder implements AffectedRecordBuilder {
+  private static final String ITEMS = "items";
+  private static final String HOLDINGS = "holdings";
+  private static final String INSTANCE_ID = "instanceId";
+  private static final String ID_KEY = "id";
+  private static final String SLASH_SEPARATOR = "/";
+
+  @Autowired
+  ConfigurationsClient configurationsClient;
+
+  @Autowired
+  AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
+
+  @Override
+  public AffectedRecord build(JsonObject record, String jobExecutionId, String recordId, boolean isLinkCreationRequired,
+                              OkapiConnectionParams params) {
+    AffectedRecord itemRecord = new AffectedRecord();
+    Optional<Pair<JsonObject, JsonObject>> itemAndRelatedHolding =
+      getItemAndRelatedHolding(record.getJsonArray(HOLDINGS), recordId);
+    if (itemAndRelatedHolding.isPresent()) {
+      itemRecord = getAffectedRecordFromJson(itemAndRelatedHolding.get().a, ITEM);
+      JsonObject holdingsRecord = itemAndRelatedHolding.get().b;
+      itemRecord.setAffectedRecords(Collections.singletonList(affectedRecordHoldingBuilder
+        .build(record, jobExecutionId, holdingsRecord.getString(ID_KEY), false, params)));
+      if (isLinkCreationRequired) {
+        String linkToInventoryRecord = configurationsClient
+          .getInventoryRecordLink(getIdsUrlPart(holdingsRecord, recordId), jobExecutionId, params);
+        if (StringUtils.isNotEmpty(linkToInventoryRecord)) {
+          itemRecord.setInventoryRecordLink(linkToInventoryRecord);
+        }
+      }
+    }
+    return itemRecord;
+  }
+
+  private String getIdsUrlPart(JsonObject holding, String itemId) {
+    return StringUtils.joinWith(
+      SLASH_SEPARATOR, holding.getString(INSTANCE_ID), holding.getString(ID_KEY), itemId);
+  }
+
+  private Optional<Pair<JsonObject, JsonObject>> getItemAndRelatedHolding(
+    JsonArray holdings, String itemRecordId) {
+    for (Object recordObj : holdings) {
+      JsonObject holding = JsonObject.mapFrom(recordObj);
+      JsonArray items = holding.getJsonArray(ITEMS);
+      for (Object itemObj : items) {
+        JsonObject item = JsonObject.mapFrom(itemObj);
+        if (itemRecordId.equals(item.getString(ID_KEY))) {
+          return Optional.of(new Pair<>(item, holding));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/org/folio/service/logs/ErrorLogService.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogService.java
@@ -2,9 +2,11 @@ package org.folio.service.logs;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import org.folio.processor.error.TranslationException;
 import org.folio.rest.jaxrs.model.ErrorLog;
 import org.folio.rest.jaxrs.model.ErrorLogCollection;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.util.OkapiConnectionParams;
 
 import java.util.Collection;
 import java.util.List;
@@ -71,10 +73,10 @@ public interface ErrorLogService {
    * @param record         {@link JsonObject} inventory record that is cause of the error
    * @param reason         the reason of the error
    * @param jobExecutionId id of specific job execution
-   * @param tenantId       id of specific tenant
+   * @param params         okapi connection parameters
    * @return future with saved {@link ErrorLog}
    */
-  Future<ErrorLog> saveWithAffectedRecord(JsonObject record, String reason, String jobExecutionId, String tenantId);
+  Future<ErrorLog> saveWithAffectedRecord(JsonObject record, String reason, String jobExecutionId, TranslationException recordInfo, OkapiConnectionParams params);
 
   /**
    * Gets {@link ErrorLog}

--- a/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
@@ -85,7 +85,7 @@ public class ErrorLogServiceImpl implements ErrorLogService {
 
   @Override
   public Future<ErrorLog> saveWithAffectedRecord(JsonObject record, String reason, String jobExecutionId, TranslationException translationException, OkapiConnectionParams params) {
-    AffectedRecord affectedRecord;
+    AffectedRecord affectedRecord = new AffectedRecord();
     RecordInfo recordInfo = translationException.getRecordInfo();
     if (recordInfo.getType().isInstance()) {
       affectedRecord = affectedRecordsBuilders
@@ -95,7 +95,7 @@ public class ErrorLogServiceImpl implements ErrorLogService {
       affectedRecord = affectedRecordsBuilders
         .get(AffectedRecordHoldingBuilder.class.getName())
         .build(record, jobExecutionId, recordInfo.getId(), true, params);
-    } else {
+    } else if (recordInfo.getType().isItem()){
       affectedRecord = affectedRecordsBuilders
         .get(AffectedRecordItemBuilder.class.getName())
         .build(record, jobExecutionId, recordInfo.getId(), true, params);

--- a/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
+++ b/src/main/java/org/folio/service/logs/ErrorLogServiceImpl.java
@@ -2,34 +2,33 @@ package org.folio.service.logs;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.dao.ErrorLogDao;
+import org.folio.processor.error.RecordInfo;
+import org.folio.processor.error.TranslationException;
 import org.folio.rest.jaxrs.model.AffectedRecord;
 import org.folio.rest.jaxrs.model.ErrorLog;
 import org.folio.rest.jaxrs.model.ErrorLogCollection;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.util.HelperUtils;
+import org.folio.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
-import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.HOLDINGS;
-import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.INSTANCE;
-import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.ITEM;
 import static org.folio.util.ErrorCode.SOME_RECORDS_FAILED;
 import static org.folio.util.ErrorCode.SOME_UUIDS_NOT_FOUND;
 import static org.folio.util.HelperUtils.getErrorLogCriterionByJobExecutionIdAndReasons;
@@ -37,15 +36,14 @@ import static org.folio.util.HelperUtils.getErrorLogCriterionByJobExecutionIdAnd
 @Service
 public class ErrorLogServiceImpl implements ErrorLogService {
   private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private static final String HRID_KEY = "hrid";
-  private static final String ID_KEY = "id";
-  private static final String TITLE_KEY = "title";
-  private static final String ITEMS = "items";
-  private static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
   private static final String COMMA_SEPARATOR = ", ";
 
   @Autowired
   private ErrorLogDao errorLogDao;
+
+  @Autowired
+  @Qualifier("affectedRecordBuilders")
+  private Map<String, AffectedRecordBuilder> affectedRecordsBuilders;
 
   @Override
   public Future<ErrorLogCollection> get(String jobExecutionId, int offset, int limit, String tenantId) {
@@ -86,22 +84,28 @@ public class ErrorLogServiceImpl implements ErrorLogService {
   }
 
   @Override
-  public Future<ErrorLog> saveWithAffectedRecord(JsonObject record, String reason, String jobExecutionId, String tenantId) {
-    JsonObject instance = record.getJsonObject(INSTANCE.toString().toLowerCase());
-    AffectedRecord instanceRecord = new AffectedRecord();
-    if (Objects.isNull(instance)) {
-      instanceRecord.setRecordType(INSTANCE);
+  public Future<ErrorLog> saveWithAffectedRecord(JsonObject record, String reason, String jobExecutionId, TranslationException translationException, OkapiConnectionParams params) {
+    AffectedRecord affectedRecord;
+    RecordInfo recordInfo = translationException.getRecordInfo();
+    if (recordInfo.getType().isInstance()) {
+      affectedRecord = affectedRecordsBuilders
+        .get(AffectedRecordInstanceBuilder.class.getName())
+        .build(record, jobExecutionId, recordInfo.getId(), true, params);
+    } else if (recordInfo.getType().isHolding()) {
+      affectedRecord = affectedRecordsBuilders
+        .get(AffectedRecordHoldingBuilder.class.getName())
+        .build(record, jobExecutionId, recordInfo.getId(), true, params);
     } else {
-      instanceRecord = getAffectedRecordFromJson(record.getJsonObject(INSTANCE.toString().toLowerCase()), INSTANCE);
-      List<AffectedRecord> holdingsAndAssociatedItems = getRecordsForHoldingAndAssociatedItems(record);
-      instanceRecord.setAffectedRecords(holdingsAndAssociatedItems);
+      affectedRecord = affectedRecordsBuilders
+        .get(AffectedRecordItemBuilder.class.getName())
+        .build(record, jobExecutionId, recordInfo.getId(), true, params);
     }
     ErrorLog errorLog = new ErrorLog()
-      .withAffectedRecord(instanceRecord)
+      .withAffectedRecord(affectedRecord)
       .withReason(reason)
       .withLogLevel(ErrorLog.LogLevel.ERROR)
       .withJobExecutionId(jobExecutionId);
-    return save(errorLog, tenantId);
+    return save(errorLog, params.getTenantId());
   }
 
   @Override
@@ -155,45 +159,6 @@ public class ErrorLogServiceImpl implements ErrorLogService {
         .onFailure(ar -> promise.complete(false));
 
     return promise.future();
-  }
-
-  private List<AffectedRecord> getRecordsForHoldingAndAssociatedItems(JsonObject record) {
-    List<AffectedRecord> holdingsAndAssociatedItems = new ArrayList<>();
-    JsonArray holdings = record.getJsonArray(HOLDINGS.toString().toLowerCase());
-    if (Objects.nonNull(holdings)) {
-      for (Object holding : holdings) {
-        JsonObject holdingJson = JsonObject.mapFrom(holding);
-        AffectedRecord holdingRecord = getAffectedRecordFromJson(holdingJson, AffectedRecord.RecordType.HOLDINGS);
-        holdingRecord.setAffectedRecords(getAssociatedItemRecords(holdingJson.getJsonArray(ITEMS)));
-        holdingsAndAssociatedItems.add(holdingRecord);
-      }
-    }
-    return holdingsAndAssociatedItems;
-  }
-
-  private List<AffectedRecord> getAssociatedItemRecords(JsonArray items) {
-    List<AffectedRecord> associatedItemRecords = new ArrayList<>();
-    if (Objects.nonNull(items)) {
-      for (Object item : items) {
-        associatedItemRecords.add(getAffectedRecordFromJson(JsonObject.mapFrom(item), ITEM));
-      }
-    }
-    return associatedItemRecords;
-  }
-
-  private AffectedRecord getAffectedRecordFromJson(JsonObject recordJson, AffectedRecord.RecordType recordType) {
-    AffectedRecord record = new AffectedRecord()
-      .withRecordType(recordType);
-    if (StringUtils.isNotBlank(recordJson.getString(HRID_KEY))) {
-      record.setHrid(recordJson.getString(HRID_KEY));
-    }
-    if (StringUtils.isNotBlank(recordJson.getString(ID_KEY))) {
-      record.setId(recordJson.getString(ID_KEY));
-    }
-    if (StringUtils.isNotBlank(recordJson.getString(TITLE_KEY))) {
-      record.setTitle(recordJson.getString(TITLE_KEY));
-    }
-    return record;
   }
 
 }

--- a/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
+++ b/src/main/java/org/folio/service/manager/input/InputDataManagerImpl.java
@@ -39,7 +39,7 @@ import static io.vertx.core.Future.succeededFuture;
 import static java.util.Objects.nonNull;
 import static org.folio.rest.jaxrs.model.FileDefinition.UploadFormat.CQL;
 import static org.folio.service.manager.export.ExportResult.ExportStatus.COMPLETED_WITH_ERRORS;
-import static org.folio.util.ErrorCode.reasonsAccordingToUUIDs;
+import static org.folio.util.ErrorCode.reasonsAccordingToExport;
 
 /**
  * Acts a source of a uuids to be exported.
@@ -177,7 +177,7 @@ class InputDataManagerImpl implements InputDataManager {
     if (status.equals(JobExecution.Status.COMPLETED)) {
       // check if there were any errors in the previous batches , if yes then complete the job with
       // "Completed with errors" status
-      isErrorsRelatedToUUIDsPresent(jobExecutionId, tenantId)
+      isSelectedErrorsPresent(jobExecutionId, tenantId)
           .onComplete(
               isAnyErrorPresent -> {
                 if (isAnyErrorPresent.succeeded()
@@ -195,10 +195,10 @@ class InputDataManagerImpl implements InputDataManager {
     removeInputDataContext(jobExecutionId);
   }
 
-  private Future<Boolean> isErrorsRelatedToUUIDsPresent(String jobExecutionId, String tenantId) {
+  private Future<Boolean> isSelectedErrorsPresent(String jobExecutionId, String tenantId) {
     Promise<Boolean> promise = Promise.promise();
     errorLogService
-        .isErrorsByReasonPresent(reasonsAccordingToUUIDs(), jobExecutionId, tenantId)
+        .isErrorsByReasonPresent(reasonsAccordingToExport(), jobExecutionId, tenantId)
         .onSuccess(promise::complete)
         .onFailure(ar -> promise.complete(false));
 

--- a/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
+++ b/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
@@ -98,7 +98,7 @@ public class MappingServiceImpl implements MappingService {
     RecordWriter recordWriter = new MarcRecordWriter();
     String record = ruleProcessor.process(entityReader, recordWriter, referenceData, rules, (translationException -> {
       LOGGER.debug("Exception occurred while mapping, exception: {}, inventory instance: {}", translationException.getCause(), instance);
-      String reason = String.format("An error occurred during fields mapping, reason: %s, cause: %s ", translationException.getErrorCode().getDescription(), translationException.getMessage());
+      String reason = String.format("An error occurred during fields mapping, reason: %s, cause: %s", translationException.getErrorCode().getDescription(), translationException.getMessage());
       errorLogService.saveWithAffectedRecord(instance, reason, jobExecutionId, translationException, connectionParams);
     }));
     return Optional.of(record);

--- a/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
+++ b/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
@@ -5,8 +5,8 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.clients.ConfigurationsClient;
-import org.folio.processor.referencedata.ReferenceData;
 import org.folio.processor.RuleProcessor;
+import org.folio.processor.referencedata.ReferenceData;
 import org.folio.processor.rule.Rule;
 import org.folio.processor.translations.TranslationsFunctionHolder;
 import org.folio.reader.EntityReader;
@@ -85,18 +85,21 @@ public class MappingServiceImpl implements MappingService {
   private Optional<String> mapInstance(JsonObject instance, ReferenceData referenceData, List<Rule> originalRules, String jobExecutionId, OkapiConnectionParams connectionParams) {
     try {
       List<Rule> finalRules = RuleHandler.preHandle(instance, originalRules);
-      return mapInstance(instance, referenceData, finalRules);
+      return mapInstance(instance, referenceData, jobExecutionId, finalRules, connectionParams);
     } catch (Exception e) {
       LOGGER.debug("Exception occurred while mapping, exception: {}, inventory instance: {}", e, instance);
-      errorLogService.saveWithAffectedRecord(instance, "An error occurred during fields mapping", jobExecutionId, connectionParams.getTenantId());
+      errorLogService.saveGeneralError("An error occurred during fields mapping", jobExecutionId, connectionParams.getTenantId());
       return Optional.empty();
     }
   }
 
-  protected Optional<String> mapInstance(JsonObject instance, ReferenceData referenceData, List<Rule> rules) {
+  protected Optional<String> mapInstance(JsonObject instance, ReferenceData referenceData, String jobExecutionId,  List<Rule> rules, OkapiConnectionParams connectionParams) {
     EntityReader entityReader = new JPathSyntaxEntityReader(instance);
     RecordWriter recordWriter = new MarcRecordWriter();
-    String record = ruleProcessor.process(entityReader, recordWriter, referenceData, rules, (translationException  -> {}));
+    String record = ruleProcessor.process(entityReader, recordWriter, referenceData, rules, (translationException -> {
+      LOGGER.debug("Exception occurred while mapping, exception: {}, inventory instance: {}", translationException.getCause(), instance);
+      errorLogService.saveWithAffectedRecord(instance, "An error occurred during fields mapping: reason - " + translationException.getErrorCode().getDescription(), jobExecutionId, translationException, connectionParams);
+    }));
     return Optional.of(record);
   }
 
@@ -110,7 +113,9 @@ public class MappingServiceImpl implements MappingService {
     List<Rule> rules = getRules(mappingProfile, jobExecutionId, connectionParams);
     EntityReader entityReader = new JPathSyntaxEntityReader(record);
     RecordWriter recordWriter = new MarcRecordWriter();
-    return ruleProcessor.processFields(entityReader, recordWriter, referenceData, rules, (translationException -> {}));
+    return ruleProcessor.processFields(entityReader, recordWriter, referenceData, rules, (translationException ->
+      errorLogService.saveGeneralError("An error occurred during fields mapping for srs record with id: "
+        + translationException.getRecordInfo().getId(), jobExecutionId, connectionParams.getTenantId())));
   }
 
   private List<Rule> getRules(MappingProfile mappingProfile, String jobExecutionId, OkapiConnectionParams params) {

--- a/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
+++ b/src/main/java/org/folio/service/mapping/MappingServiceImpl.java
@@ -98,7 +98,8 @@ public class MappingServiceImpl implements MappingService {
     RecordWriter recordWriter = new MarcRecordWriter();
     String record = ruleProcessor.process(entityReader, recordWriter, referenceData, rules, (translationException -> {
       LOGGER.debug("Exception occurred while mapping, exception: {}, inventory instance: {}", translationException.getCause(), instance);
-      errorLogService.saveWithAffectedRecord(instance, "An error occurred during fields mapping: reason - " + translationException.getErrorCode().getDescription(), jobExecutionId, translationException, connectionParams);
+      String reason = String.format("An error occurred during fields mapping, reason: %s, cause: %s ", translationException.getErrorCode().getDescription(), translationException.getMessage());
+      errorLogService.saveWithAffectedRecord(instance, reason, jobExecutionId, translationException, connectionParams);
     }));
     return Optional.of(record);
   }
@@ -114,8 +115,10 @@ public class MappingServiceImpl implements MappingService {
     EntityReader entityReader = new JPathSyntaxEntityReader(record);
     RecordWriter recordWriter = new MarcRecordWriter();
     return ruleProcessor.processFields(entityReader, recordWriter, referenceData, rules, (translationException ->
-      errorLogService.saveGeneralError("An error occurred during fields mapping for srs record with id: "
-        + translationException.getRecordInfo().getId(), jobExecutionId, connectionParams.getTenantId())));
+      errorLogService.saveGeneralError(String.format("An error occurred during fields mapping for srs record with " +
+          "id: %s, reason: %s, cause: %s ", translationException.getRecordInfo().getId(),
+        translationException.getErrorCode().getDescription(), translationException.getMessage()),
+        jobExecutionId, connectionParams.getTenantId())));
   }
 
   private List<Rule> getRules(MappingProfile mappingProfile, String jobExecutionId, OkapiConnectionParams params) {

--- a/src/main/java/org/folio/util/ErrorCode.java
+++ b/src/main/java/org/folio/util/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
   INVALID_UUID_FORMAT("invalidUUIDFormat", "Invalid UUID format: "),
   INVALID_EXPORT_FILE_DEFINITION_ID("invalidExportFileDefinitionId", "Invalid export file definition id: "),
   FAIL_TO_UPDATE_JOB("failToUpdateJob", "Fail to prepare job execution for export"),
-  DEFAULT_MAPPING_PROFILE_NOT_FOUND("defaultMappingProfileNotFound", "Default mapping profile not found");
+  DEFAULT_MAPPING_PROFILE_NOT_FOUND("defaultMappingProfileNotFound", "Default mapping profile not found"),
+  DATE_PARSE_ERROR_CODE("errorDuringParsingDate", "An error occurs during parsing the date while the mapping process"),
+  UNDEFINED("undefined", "undefined");
 
   private final String code;
   private final String description;
@@ -47,11 +49,13 @@ public enum ErrorCode {
     return new Error().withCode(code).withMessage(description);
   }
 
-  public static List<String> reasonsAccordingToUUIDs() {
+  public static List<String> reasonsAccordingToExport() {
     List<String> errorCodesForUUIDs = new ArrayList<>();
     errorCodesForUUIDs.add(SOME_UUIDS_NOT_FOUND.getDescription());
     errorCodesForUUIDs.add(SOME_RECORDS_FAILED.getDescription());
     errorCodesForUUIDs.add(INVALID_UUID_FORMAT.getDescription());
+    errorCodesForUUIDs.add(DATE_PARSE_ERROR_CODE.getDescription());
+    errorCodesForUUIDs.add(UNDEFINED.getDescription());
     return errorCodesForUUIDs;
   }
 }

--- a/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
+++ b/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
@@ -107,17 +107,18 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
     Optional<JsonObject> recordLink = configurationsClient.getConfigsFromModConfigByQuery(JOB_EXECUTION_ID, "FAIL", okapiConnectionParams);
 
     // then
-    context.verify(() -> {
-      Assert.assertTrue(recordLink.isEmpty());
-      Criterion criterion = HelperUtils.getErrorLogCriterionByJobExecutionIdAndReason(JOB_EXECUTION_ID, "Error while query the configs from mod configuration by query");
-      errorLogService.getByQuery(criterion, okapiConnectionParams.getTenantId())
-        .onSuccess(errorLogList -> {
-          Assertions.assertNotNull(errorLogList);
-          Assertions.assertFalse(errorLogList.isEmpty());
-          Assertions.assertEquals(JOB_EXECUTION_ID, errorLogList.get(0).getJobExecutionId());
-          context.completeNow();
-        });
-    });
+    vertx.setTimer(2000L, handler ->
+      context.verify(() -> {
+        Assert.assertTrue(recordLink.isEmpty());
+        Criterion criterion = HelperUtils.getErrorLogCriterionByJobExecutionIdAndReason(JOB_EXECUTION_ID, "Error while query the configs from mod configuration by query");
+        errorLogService.getByQuery(criterion, okapiConnectionParams.getTenantId())
+          .onSuccess(errorLogList -> {
+            Assertions.assertNotNull(errorLogList);
+            Assertions.assertFalse(errorLogList.isEmpty());
+            Assertions.assertEquals(JOB_EXECUTION_ID, errorLogList.get(0).getJobExecutionId());
+            context.completeNow();
+          });
+      }));
 
   }
 

--- a/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
+++ b/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
@@ -1,22 +1,37 @@
 package org.folio.rest.impl;
 
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import org.apache.commons.collections4.map.HashedMap;
 import org.folio.clients.ConfigurationsClient;
 import org.folio.processor.rule.Rule;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.service.ApplicationTestConfig;
+import org.folio.service.logs.ErrorLogService;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.HelperUtils;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 @RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 class ConfigurationsClientTest extends RestVerticleTestBase {
   private static final String DEFAULT_LEADER_FIELD_NAME = "leader";
   private static final String DEFAULT_LEADER_FIELD_DESCRIPTION = "Leader";
@@ -26,6 +41,18 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
   private static final String DEFAULT_LEADER_TRANSLATION_PARAMETERS_POS19 = " ";
   private static final String JOB_EXECUTION_ID = UUID.randomUUID().toString();
   private static OkapiConnectionParams okapiConnectionParams;
+
+  @Autowired
+  ConfigurationsClient configurationsClient;
+  @Autowired
+  ErrorLogService errorLogService;
+
+
+  public ConfigurationsClientTest() {
+    Context vertxContext = Vertx.vertx().getOrCreateContext();
+    SpringContextUtil.init(vertxContext.owner(), vertxContext, ApplicationTestConfig.class);
+    SpringContextUtil.autowireDependencies(this, vertxContext);
+  }
 
   @BeforeAll
   public static void beforeClass() {
@@ -37,7 +64,6 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
 
   @Test
   void shouldRetrieveRulesFromModConfig() {
-    ConfigurationsClient configurationsClient = new ConfigurationsClient();
 
     //when
     List<Rule> ruleList = configurationsClient.getRulesFromConfiguration(JOB_EXECUTION_ID, okapiConnectionParams);
@@ -47,11 +73,11 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
 
   @Test
   void shouldRetrieveRulesFromModConfigThatEqualsToDefault() {
-    ConfigurationsClient configurationsClient = new ConfigurationsClient();
 
-    //when
+    // when
     List<Rule> ruleList = configurationsClient.getRulesFromConfiguration(JOB_EXECUTION_ID, okapiConnectionParams);
 
+    // then
     Assert.assertEquals(DEFAULT_LEADER_FIELD_NAME, ruleList.get(0).getField());
     Assert.assertEquals(DEFAULT_LEADER_FIELD_DESCRIPTION, ruleList.get(0).getDescription());
     Assert.assertEquals(DEFAULT_LEADER_TRANSLATION_FUNCTION, ruleList.get(0).getDataSources().get(0).getTranslation().getFunction());
@@ -62,14 +88,36 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
 
   @Test
   void shouldRetrieveRecordLinkFromModConfig() {
-    ConfigurationsClient configurationsClient = new ConfigurationsClient();
+    // given
     String id = UUID.randomUUID().toString();
     String expectedLink = "https://folio-testing.dev.folio.org/inventory/view/" + id;
 
-    //when
+    // when
     String recordLink = configurationsClient.getInventoryRecordLink(id, JOB_EXECUTION_ID, okapiConnectionParams);
 
+    // then
     Assert.assertEquals(expectedLink, recordLink);
+
+  }
+
+  @Test
+  void shouldReturnEmptyWhenResponseIsFail(VertxTestContext context) {
+
+    //when
+    Optional<JsonObject> recordLink = configurationsClient.getConfigsFromModConfigByQuery(JOB_EXECUTION_ID, "FAIL", okapiConnectionParams);
+
+    // then
+    context.verify(() -> {
+      Assert.assertTrue(recordLink.isEmpty());
+      Criterion criterion = HelperUtils.getErrorLogCriterionByJobExecutionIdAndReason(JOB_EXECUTION_ID, "Error while query the configs from mod configuration by query");
+      errorLogService.getByQuery(criterion, okapiConnectionParams.getTenantId())
+        .onSuccess(errorLogList -> {
+          Assertions.assertNotNull(errorLogList);
+          Assertions.assertFalse(errorLogList.isEmpty());
+          Assertions.assertEquals(JOB_EXECUTION_ID, errorLogList.get(0).getJobExecutionId());
+          context.completeNow();
+        });
+    });
 
   }
 

--- a/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
+++ b/src/test/java/org/folio/rest/impl/ConfigurationsClientTest.java
@@ -60,4 +60,17 @@ class ConfigurationsClientTest extends RestVerticleTestBase {
     Assert.assertEquals(DEFAULT_LEADER_TRANSLATION_PARAMETERS_POS19, ruleList.get(0).getDataSources().get(0).getTranslation().getParameter("position19"));
   }
 
+  @Test
+  void shouldRetrieveRecordLinkFromModConfig() {
+    ConfigurationsClient configurationsClient = new ConfigurationsClient();
+    String id = UUID.randomUUID().toString();
+    String expectedLink = "https://folio-testing.dev.folio.org/inventory/view/" + id;
+
+    //when
+    String recordLink = configurationsClient.getInventoryRecordLink(id, JOB_EXECUTION_ID, okapiConnectionParams);
+
+    Assert.assertEquals(expectedLink, recordLink);
+
+  }
+
 }

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -154,7 +154,7 @@ class DataExportTest extends RestVerticleTestBase {
       jobExecutionDao.getById(jobExecutionId, tenantId).onSuccess(optionalJobExecution -> {
         JobExecution jobExecution = optionalJobExecution.get();
         fileDefinitionDao.getById(fileExportDefinitionCaptor.getValue().getId(), tenantId).onSuccess(optionalFileDefinition -> {
-          errorLogService.isErrorsByReasonPresent(ErrorCode.reasonsAccordingToUUIDs(), jobExecutionId, tenantId).onSuccess(isErrorsPresent -> {
+          errorLogService.isErrorsByReasonPresent(ErrorCode.reasonsAccordingToExport(), jobExecutionId, tenantId).onSuccess(isErrorsPresent -> {
             context.verify(() -> {
               FileDefinition fileExportDefinition = optionalFileDefinition.get();
               assertJobExecution(jobExecution, COMPLETED, EXPORTED_RECORDS_NUMBER_2);

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -75,6 +75,7 @@ public class MockServer {
   private static final String CAMPUSES_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_campuses_response.json";
   private static final String INSTITUTIONS_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_institutions_response.json";
   private static final String CONFIGURATIONS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "configurations/get_configuration_response.json";
+  private static final String CONFIGURATIONS_MOCK_DATA_PATH_FOR_HOST = BASE_MOCK_DATA_PATH + "configurations/get_host_configuration_response.json";
   private static final String MATERIAL_TYPES_RECORDS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_material_types_response.json";
   private static final String INSTANCE_TYPES_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_instance_types_response.json";
   private static final String INSTANCE_FORMATS_MOCK_DATA_PATH = BASE_MOCK_DATA_PATH + "inventory/get_instance_formats_response.json";
@@ -512,16 +513,22 @@ public class MockServer {
     logger.info("handleGetRulesFromModConfigurations got: " + ctx.request()
       .path());
     try {
-      JsonObject rulesFromConfig = new JsonObject(RestVerticleTestBase.getMockData(CONFIGURATIONS_MOCK_DATA_PATH));
-      URL url = Resources.getResource("rules/rulesDefault.json");
-      String rules = Resources.toString(url, StandardCharsets.UTF_8);
-      rulesFromConfig.getJsonArray("configs")
-        .stream()
-        .map(object -> (JsonObject) object)
-        .forEach(obj -> obj.put("value", rules));
+      if (ctx.request().getParam("query").contains("FOLIO_HOST")) {
+        JsonObject host = new JsonObject(RestVerticleTestBase.getMockData(CONFIGURATIONS_MOCK_DATA_PATH_FOR_HOST));
+        addServerRqRsData(HttpMethod.GET, CONFIGURATIONS, host);
+        serverResponse(ctx, 200, APPLICATION_JSON, host.encodePrettily());
+      } else {
+        JsonObject rulesFromConfig = new JsonObject(RestVerticleTestBase.getMockData(CONFIGURATIONS_MOCK_DATA_PATH));
+        URL url = Resources.getResource("rules/rulesDefault.json");
+        String rules = Resources.toString(url, StandardCharsets.UTF_8);
+        rulesFromConfig.getJsonArray("configs")
+          .stream()
+          .map(object -> (JsonObject) object)
+          .forEach(obj -> obj.put("value", rules));
 
-      addServerRqRsData(HttpMethod.GET, CONFIGURATIONS, rulesFromConfig);
-      serverResponse(ctx, 200, APPLICATION_JSON, rulesFromConfig.encodePrettily());
+        addServerRqRsData(HttpMethod.GET, CONFIGURATIONS, rulesFromConfig);
+        serverResponse(ctx, 200, APPLICATION_JSON, rulesFromConfig.encodePrettily());
+      }
     } catch (IOException e) {
       ctx.response()
         .setStatusCode(500)

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -28,31 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.folio.util.ExternalPathResolver.ALTERNATIVE_TITLE_TYPES;
-import static org.folio.util.ExternalPathResolver.CALL_NUMBER_TYPES;
-import static org.folio.util.ExternalPathResolver.CAMPUSES;
-import static org.folio.util.ExternalPathResolver.CONFIGURATIONS;
-import static org.folio.util.ExternalPathResolver.CONTENT_TERMS;
-import static org.folio.util.ExternalPathResolver.CONTRIBUTOR_NAME_TYPES;
-import static org.folio.util.ExternalPathResolver.ELECTRONIC_ACCESS_RELATIONSHIPS;
-import static org.folio.util.ExternalPathResolver.HOLDING;
-import static org.folio.util.ExternalPathResolver.HOLDING_NOTE_TYPES;
-import static org.folio.util.ExternalPathResolver.IDENTIFIER_TYPES;
-import static org.folio.util.ExternalPathResolver.INSTANCE;
-import static org.folio.util.ExternalPathResolver.INSTANCE_BULK_IDS;
-import static org.folio.util.ExternalPathResolver.INSTANCE_FORMATS;
-import static org.folio.util.ExternalPathResolver.INSTANCE_TYPES;
-import static org.folio.util.ExternalPathResolver.INSTITUTIONS;
-import static org.folio.util.ExternalPathResolver.ISSUANCE_MODES;
-import static org.folio.util.ExternalPathResolver.ITEM;
-import static org.folio.util.ExternalPathResolver.ITEM_NOTE_TYPES;
-import static org.folio.util.ExternalPathResolver.LIBRARIES;
-import static org.folio.util.ExternalPathResolver.LOAN_TYPES;
-import static org.folio.util.ExternalPathResolver.LOCATIONS;
-import static org.folio.util.ExternalPathResolver.MATERIAL_TYPES;
-import static org.folio.util.ExternalPathResolver.SRS;
-import static org.folio.util.ExternalPathResolver.USERS;
-import static org.folio.util.ExternalPathResolver.resourcesPath;
+import static org.folio.util.ExternalPathResolver.*;
 import static org.junit.Assert.fail;
 
 public class MockServer {
@@ -517,6 +493,10 @@ public class MockServer {
         JsonObject host = new JsonObject(RestVerticleTestBase.getMockData(CONFIGURATIONS_MOCK_DATA_PATH_FOR_HOST));
         addServerRqRsData(HttpMethod.GET, CONFIGURATIONS, host);
         serverResponse(ctx, 200, APPLICATION_JSON, host.encodePrettily());
+      } else if (ctx.request().getParam("query").contains("FAIL")) {
+        ctx.response()
+          .setStatusCode(500)
+          .end();
       } else {
         JsonObject rulesFromConfig = new JsonObject(RestVerticleTestBase.getMockData(CONFIGURATIONS_MOCK_DATA_PATH));
         URL url = Resources.getResource("rules/rulesDefault.json");

--- a/src/test/java/org/folio/service/ApplicationTestConfig.java
+++ b/src/test/java/org/folio/service/ApplicationTestConfig.java
@@ -21,16 +21,11 @@ import java.util.Map;
   "org.folio.rest.impl"})
 public class ApplicationTestConfig {
 
-  @Autowired
-  AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
-  @Autowired
-  AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
-  @Autowired
-  AffectedRecordItemBuilder affectedRecordItemBuilder;
-
   @Bean
   @Qualifier("affectedRecordBuilders")
-  public Map<String, AffectedRecordBuilder> getBuilders() {
+  public Map<String, AffectedRecordBuilder> getBuilders(@Autowired AffectedRecordInstanceBuilder affectedRecordInstanceBuilder,
+                                                        @Autowired AffectedRecordHoldingBuilder affectedRecordHoldingBuilder,
+                                                        @Autowired AffectedRecordItemBuilder affectedRecordItemBuilder) {
     Map<String, AffectedRecordBuilder> builders = new HashMap<>();
     builders.put(AffectedRecordInstanceBuilder.class.getName(), affectedRecordInstanceBuilder);
     builders.put(AffectedRecordHoldingBuilder.class.getName(), affectedRecordHoldingBuilder);

--- a/src/test/java/org/folio/service/ApplicationTestConfig.java
+++ b/src/test/java/org/folio/service/ApplicationTestConfig.java
@@ -1,7 +1,17 @@
 package org.folio.service;
 
+import org.folio.service.logs.AffectedRecordBuilder;
+import org.folio.service.logs.AffectedRecordHoldingBuilder;
+import org.folio.service.logs.AffectedRecordInstanceBuilder;
+import org.folio.service.logs.AffectedRecordItemBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @ComponentScan(basePackages = {
@@ -10,4 +20,22 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.clients",
   "org.folio.rest.impl"})
 public class ApplicationTestConfig {
+
+  @Autowired
+  AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
+  @Autowired
+  AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
+  @Autowired
+  AffectedRecordItemBuilder affectedRecordItemBuilder;
+
+  @Bean
+  @Qualifier("affectedRecordBuilders")
+  public Map<String, AffectedRecordBuilder> getBuilders() {
+    Map<String, AffectedRecordBuilder> builders = new HashMap<>();
+    builders.put(AffectedRecordInstanceBuilder.class.getName(), affectedRecordInstanceBuilder);
+    builders.put(AffectedRecordHoldingBuilder.class.getName(), affectedRecordHoldingBuilder);
+    builders.put(AffectedRecordItemBuilder.class.getName(), affectedRecordItemBuilder);
+    return builders;
+  }
+
 }

--- a/src/test/java/org/folio/service/logs/builder/AffectedRecordHoldingBuilderUnitTest.java
+++ b/src/test/java/org/folio/service/logs/builder/AffectedRecordHoldingBuilderUnitTest.java
@@ -1,0 +1,113 @@
+package org.folio.service.logs.builder;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.collections4.map.HashedMap;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.service.ApplicationTestConfig;
+import org.folio.service.logs.AffectedRecordHoldingBuilder;
+import org.folio.service.logs.AffectedRecordInstanceBuilder;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.OkapiConnectionParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.folio.TestUtil.readFileContentFromResources;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.impl.RestVerticleTestBase.TENANT_ID;
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.HOLDINGS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+class AffectedRecordHoldingBuilderUnitTest {
+
+  private static final String INSTANCE_ID = "a89eccf0-57a6-495e-898d-32b9b2210f2f";
+  private static final String HOLDING_ID = "67cd0046-e4f1-4e4f-9024-adf0b0039d09";
+  private static final String INSTANCE_HR_ID = "inst000000000017";
+  private static final String HOLDING_HR_ID = "hold000000000007";
+  private static final String INSTANCE_TITLE = "Interesting Times";
+  private static OkapiConnectionParams params;
+  @Spy
+  @InjectMocks
+  private AffectedRecordHoldingBuilder affectedRecordBuilder;
+  @Mock
+  private AffectedRecordInstanceBuilder affectedRecordInstanceBuilder;
+  @Mock
+  private ConfigurationsClient configurationsClient;
+
+  public AffectedRecordHoldingBuilderUnitTest() {
+    Context vertxContext = Vertx.vertx().getOrCreateContext();
+    SpringContextUtil.init(vertxContext.owner(), vertxContext, ApplicationTestConfig.class);
+    SpringContextUtil.autowireDependencies(this, vertxContext);
+  }
+
+  @BeforeAll
+  static void beforeAll() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
+    params = new OkapiConnectionParams(headers);
+  }
+
+  @Test
+  void buildAffectedRecord_shouldReturnAffectedHoldingRecord_instanceAsRelated() {
+    // given
+    String expectedLink = "localhost:3000/inventory/view/a89eccf0-57a6-495e-898d-32b9b2210f2f/67cd0046-e4f1-4e4f-9024-adf0b0039d09";
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+    Mockito.when(configurationsClient.getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class)))
+      .thenReturn(expectedLink);
+    doCallRealMethod().when(affectedRecordInstanceBuilder).build(record, "jobId", INSTANCE_ID, false, params);
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", HOLDING_ID, true, params);
+
+    // then
+    assertEquals(HOLDING_ID, affectedRecord.getId());
+    assertEquals(HOLDING_HR_ID, affectedRecord.getHrid());
+    assertEquals(HOLDINGS, affectedRecord.getRecordType());
+    assertEquals(expectedLink, affectedRecord.getInventoryRecordLink());
+    assertEquals(1, affectedRecord.getAffectedRecords().size());
+    assertTrue(Objects.isNull(affectedRecord.getTitle()));
+    Mockito.verify(configurationsClient, times(1))
+      .getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class));
+  }
+
+  @Test
+  void
+  buildAffectedRecord_shouldReturnAffectedHoldingRecordWithoutLink_IfLinkCreationNotRequired() {
+    // given
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+    doCallRealMethod().when(affectedRecordInstanceBuilder).build(record, "jobId", INSTANCE_ID, false, params);
+
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", HOLDING_ID, false, params);
+
+    // then
+    assertEquals(HOLDING_ID, affectedRecord.getId());
+    assertEquals(HOLDING_HR_ID, affectedRecord.getHrid());
+    assertEquals(HOLDINGS, affectedRecord.getRecordType());
+    assertTrue(Objects.isNull(affectedRecord.getInventoryRecordLink()));
+    verify(configurationsClient, never()).getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class));
+    assertEquals(1, affectedRecord.getAffectedRecords().size());
+    assertTrue(Objects.isNull(affectedRecord.getTitle()));
+  }
+}

--- a/src/test/java/org/folio/service/logs/builder/AffectedRecordInstanceBuilderUnitTest.java
+++ b/src/test/java/org/folio/service/logs/builder/AffectedRecordInstanceBuilderUnitTest.java
@@ -120,7 +120,7 @@ class AffectedRecordInstanceBuilderUnitTest {
   }
 
   @Test
-  void buildAffectedRecord_shouldBuildRecordWithTypeAndId_whenGivenJsonIsnull() {
+  void buildAffectedRecord_shouldBuildRecordWithTypeAndId_whenGivenJsonIsEmpty() {
 
     // when
     AffectedRecord affectedRecord = affectedRecordBuilder.build(new JsonObject(), "jobId", INSTANCE_ID, false, params);

--- a/src/test/java/org/folio/service/logs/builder/AffectedRecordInstanceBuilderUnitTest.java
+++ b/src/test/java/org/folio/service/logs/builder/AffectedRecordInstanceBuilderUnitTest.java
@@ -1,0 +1,98 @@
+package org.folio.service.logs.builder;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.collections4.map.HashedMap;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.service.logs.AffectedRecordInstanceBuilder;
+import org.folio.util.OkapiConnectionParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.folio.TestUtil.readFileContentFromResources;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.impl.RestVerticleTestBase.TENANT_ID;
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.INSTANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+class AffectedRecordInstanceBuilderUnitTest {
+
+  private static final String INSTANCE_ID = "a89eccf0-57a6-495e-898d-32b9b2210f2f";
+  private static final String INSTANCE_HR_ID = "inst000000000017";
+  private static final String INSTANCE_TITLE = "Interesting Times";
+  private static OkapiConnectionParams params;
+
+  @Spy
+  @InjectMocks
+  private AffectedRecordInstanceBuilder affectedRecordBuilder;
+  @Mock
+  private ConfigurationsClient configurationsClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
+    params = new OkapiConnectionParams(headers);
+  }
+
+  @Test
+  void buildAffectedRecord_shouldReturnRecordOnlyWithInstance() {
+    // given
+    String expectedLink = "localhost:3000/inventory/view/a89eccf0-57a6-495e-898d-32b9b2210f2f";
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+    Mockito.when(configurationsClient.getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class)))
+      .thenReturn(expectedLink);
+
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", INSTANCE_ID, true, params);
+
+    // then
+    assertEquals(INSTANCE_TITLE, affectedRecord.getTitle());
+    assertEquals(INSTANCE_ID, affectedRecord.getId());
+    assertEquals(INSTANCE_HR_ID, affectedRecord.getHrid());
+    assertEquals(INSTANCE, affectedRecord.getRecordType());
+    assertEquals(expectedLink, affectedRecord.getInventoryRecordLink());
+    assertTrue(affectedRecord.getAffectedRecords().isEmpty());
+    Mockito.verify(configurationsClient, times(1))
+      .getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class));
+  }
+
+  @Test
+  void buildAffectedRecord_shouldReturnRecordWithoutLink_IfLinkCreationNotRequired() {
+    // give
+
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", INSTANCE_ID, false, params);
+
+    // then
+    assertEquals(INSTANCE_TITLE, affectedRecord.getTitle());
+    assertEquals(INSTANCE_ID, affectedRecord.getId());
+    assertEquals(INSTANCE_HR_ID, affectedRecord.getHrid());
+    assertEquals(INSTANCE, affectedRecord.getRecordType());
+    assertTrue(Objects.isNull(affectedRecord.getInventoryRecordLink()));
+    verify(configurationsClient, never())
+      .getConfigsFromModConfigByQuery(anyString(), anyString(), any(OkapiConnectionParams.class));
+    assertTrue(affectedRecord.getAffectedRecords().isEmpty());
+  }
+}

--- a/src/test/java/org/folio/service/logs/builder/AffectedRecordItemBuilderUnitTest.java
+++ b/src/test/java/org/folio/service/logs/builder/AffectedRecordItemBuilderUnitTest.java
@@ -1,0 +1,111 @@
+package org.folio.service.logs.builder;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.collections4.map.HashedMap;
+import org.folio.clients.ConfigurationsClient;
+import org.folio.rest.jaxrs.model.AffectedRecord;
+import org.folio.service.ApplicationTestConfig;
+import org.folio.service.logs.AffectedRecordHoldingBuilder;
+import org.folio.service.logs.AffectedRecordItemBuilder;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.OkapiConnectionParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.folio.TestUtil.readFileContentFromResources;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.impl.RestVerticleTestBase.TENANT_ID;
+import static org.folio.rest.jaxrs.model.AffectedRecord.RecordType.ITEM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+class AffectedRecordItemBuilderUnitTest {
+
+  private static final String INSTANCE_ID = "a89eccf0-57a6-495e-898d-32b9b2210f2f";
+  private static final String HOLDING_ID = "67cd0046-e4f1-4e4f-9024-adf0b0039d09";
+  private static final String ITEM_ID = "bb5a6689-c008-4c96-8f8f-b666850ee12d";
+  private static final String ITEM_HR_ID = "item000000000012";
+  private static OkapiConnectionParams params;
+  @Spy
+  @InjectMocks
+  private AffectedRecordItemBuilder affectedRecordBuilder;
+  @Mock
+  private AffectedRecordHoldingBuilder affectedRecordHoldingBuilder;
+  @Mock
+  private ConfigurationsClient configurationsClient;
+
+  public AffectedRecordItemBuilderUnitTest() {
+    Context vertxContext = Vertx.vertx().getOrCreateContext();
+    SpringContextUtil.init(vertxContext.owner(), vertxContext, ApplicationTestConfig.class);
+    SpringContextUtil.autowireDependencies(this, vertxContext);
+  }
+
+  @BeforeAll
+  static void beforeAll() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
+    params = new OkapiConnectionParams(headers);
+  }
+
+  @Test
+  void buildAffectedRecord_shouldReturnAffectedItemRecord_HoldingAndInstanceAsRelated() {
+    // given
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+    when(affectedRecordHoldingBuilder.build(record, "jobId", HOLDING_ID, false, params)).thenReturn(null);
+    Mockito.when(configurationsClient.getInventoryRecordLink(
+      anyString(), anyString(), any(OkapiConnectionParams.class)))
+      .thenReturn("localhost:3000/inventory/view/a89eccf0-57a6-495e-898d-32b9b2210f2f/67cd0046-e4f1-4e4f-9024-adf0b0039d09/bb5a6689-c008-4c96-8f8f-b666850ee12d");
+
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", ITEM_ID, true, params);
+
+    // then
+    assertEquals(ITEM_ID, affectedRecord.getId());
+    assertEquals(ITEM_HR_ID, affectedRecord.getHrid());
+    assertEquals(ITEM, affectedRecord.getRecordType());
+    assertEquals("localhost:3000/inventory/view/" + INSTANCE_ID + "/" + HOLDING_ID + "/" + ITEM_ID,
+      affectedRecord.getInventoryRecordLink());
+    Mockito.verify(configurationsClient, times(1))
+      .getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class));
+  }
+
+  @Test
+  void buildAffectedRecord_shouldReturnAffectedItemRecordWithoutLink_IfLinkCreationNotRequired() {
+    // given
+    JsonObject record = new JsonObject(readFileContentFromResources("mapping/given_InstanceHoldingsItems.json"));
+    when(affectedRecordHoldingBuilder.build(record, "jobId", HOLDING_ID, false, params)).thenReturn(null);
+    // when
+    AffectedRecord affectedRecord = affectedRecordBuilder.build(record, "jobId", ITEM_ID, false, params);
+
+    // then
+    assertEquals(ITEM_ID, affectedRecord.getId());
+    assertEquals(ITEM_HR_ID, affectedRecord.getHrid());
+    assertEquals(ITEM, affectedRecord.getRecordType());
+    assertTrue(Objects.isNull(affectedRecord.getInventoryRecordLink()));
+    verify(configurationsClient, never())
+      .getInventoryRecordLink(anyString(), anyString(), any(OkapiConnectionParams.class));
+    assertEquals(1, affectedRecord.getAffectedRecords().size());
+    assertTrue(Objects.isNull(affectedRecord.getTitle()));
+  }
+}

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -153,7 +153,7 @@ class MappingServiceUnitTest {
     // when
     List<String> actualMarcRecords = mappingService.map(instances, new MappingProfile(), jobExecutionId, params);
     // then
-    verify(errorLogService).saveWithAffectedRecord(any(JsonObject.class), eq("An error occurred during fields mapping: reason - undefined"), eq(jobExecutionId), any(TranslationException.class), any(OkapiConnectionParams.class));
+    verify(errorLogService).saveWithAffectedRecord(any(JsonObject.class), eq("An error occurred during fields mapping, reason: undefined, cause: java.lang.NullPointerException"), eq(jobExecutionId), any(TranslationException.class), any(OkapiConnectionParams.class));
 
   }
 

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -91,6 +91,7 @@ import static org.folio.util.ExternalPathResolver.LOAN_TYPES;
 import static org.folio.util.ExternalPathResolver.LOCATIONS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
@@ -166,7 +167,7 @@ class MappingServiceUnitTest {
 
 
   @Test
-  void shouldPopulateErrorLog_whenMappingFailed() throws FileNotFoundException {
+  void shouldPopulateErrorLog_whenMappingFailed() {
     // given
     JsonObject instance = new JsonObject(readFileContentFromResources("mapping/given_inventory_instance.json"));
     List<JsonObject> instances = Collections.singletonList(instance);
@@ -174,11 +175,11 @@ class MappingServiceUnitTest {
       .thenReturn(referenceData);
     Mockito.when(configurationsClient.getRulesFromConfiguration(eq(jobExecutionId), any(OkapiConnectionParams.class)))
       .thenReturn(Collections.emptyList());
-    doThrow(RuntimeException.class).when(mappingService).mapInstance(any(JsonObject.class), any(ReferenceData.class), anyList());
+    doThrow(RuntimeException.class).when(mappingService).mapInstance(any(JsonObject.class), any(ReferenceData.class), anyString(), anyList(), any(OkapiConnectionParams.class));
     // when
     mappingService.map(instances, new MappingProfile(), jobExecutionId, params);
     // then
-    verify(errorLogService).saveWithAffectedRecord(instance, "An error occurred during fields mapping", jobExecutionId, params.getTenantId());
+    verify(errorLogService).saveGeneralError(eq("An error occurred during fields mapping"), eq(jobExecutionId),  any());
   }
 
   @Test

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -140,7 +140,7 @@ class MappingServiceUnitTest {
   }
 
   @Test
-  void shouldCallSaveAffectedRecord_whenReferenceDataIsNull_asManyTimes_asErrorsOccurs() {
+  void shouldCallSaveAffectedRecord_whenReferenceDataIsNull() {
     // given
     JsonObject instance = new JsonObject(readFileContentFromResources("mapping/given_small_instanceHolding.json"));
     List<JsonObject> instances = Collections.singletonList(instance);
@@ -156,7 +156,7 @@ class MappingServiceUnitTest {
   }
 
   @Test
-  void shouldReturnVariableFieldsForHoldingsAndItem_whenMappingProfileTransformationsAreProvided2() throws FileNotFoundException {
+  void shouldSaveGeneralError_whenReferenceDataIsNull() {
     // given
     JsonObject srsRecord = new JsonObject(readFileContentFromResources("mapping/given_HoldingsItems.json"));
     String expectedReason = "An error occurred during fields mapping for srs record with id: 65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61, reason: undefined, cause: java.lang.NullPointerException ";

--- a/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
+++ b/src/test/java/org/folio/service/mapping/MappingServiceUnitTest.java
@@ -6,6 +6,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.folio.TestUtil;
 import org.folio.clients.ConfigurationsClient;
+import org.folio.processor.error.RecordInfo;
 import org.folio.processor.error.TranslationException;
 import org.folio.processor.referencedata.ReferenceData;
 import org.folio.processor.rule.Rule;
@@ -143,7 +144,7 @@ class MappingServiceUnitTest {
   @Test
   void shouldCallSaveAffectedRecord_whenReferenceDataIsNull_asManyTimes_asErrorsOccurs() {
     // given
-    JsonObject instance = new JsonObject(readFileContentFromResources("mapping/given_inventory_instance.json"));
+    JsonObject instance = new JsonObject(readFileContentFromResources("mapping/given_small_instance.json"));
     List<JsonObject> instances = Collections.singletonList(instance);
     Mockito.when(referenceDataProvider.get(jobExecutionId, params))
       .thenReturn(null);
@@ -152,7 +153,7 @@ class MappingServiceUnitTest {
     // when
     List<String> actualMarcRecords = mappingService.map(instances, new MappingProfile(), jobExecutionId, params);
     // then
-    verify(errorLogService, times(59)).saveWithAffectedRecord(any(JsonObject.class), eq("An error occurred during fields mapping: reason - undefined"), eq(jobExecutionId), any(TranslationException.class), any(OkapiConnectionParams.class));
+    verify(errorLogService).saveWithAffectedRecord(any(JsonObject.class), eq("An error occurred during fields mapping: reason - undefined"), eq(jobExecutionId), any(TranslationException.class), any(OkapiConnectionParams.class));
 
   }
 

--- a/src/test/resources/mapping/given_InstanceHoldingsItems.json
+++ b/src/test/resources/mapping/given_InstanceHoldingsItems.json
@@ -1,0 +1,165 @@
+{
+  "instance":{
+    "id":"a89eccf0-57a6-495e-898d-32b9b2210f2f",
+    "hrid":"inst000000000017",
+    "source":"FOLIO",
+    "title":"Interesting Times",
+    "alternativeTitles":[
+
+    ],
+    "editions":[
+
+    ],
+    "series":[
+
+    ],
+    "identifiers":[
+      {
+        "value":"0552142352",
+        "identifierTypeId":"8261054f-be78-422d-bd51-4ed9f33c3422"
+      },
+      {
+        "value":"9780552142352",
+        "identifierTypeId":"8261054f-be78-422d-bd51-4ed9f33c3422"
+      }
+    ],
+    "contributors":[
+      {
+        "name":"Pratchett, Terry",
+        "contributorNameTypeId":"2b94c631-fca9-4892-a730-03ee529ffe2a"
+      }
+    ],
+    "subjects":[
+
+    ],
+    "classifications":[
+
+    ],
+    "publication":[
+
+    ],
+    "publicationFrequency":[
+
+    ],
+    "publicationRange":[
+
+    ],
+    "electronicAccess":[
+
+    ],
+    "instanceTypeId":"6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+    "instanceFormatIds":[
+
+    ],
+    "instanceFormats":[
+
+    ],
+    "physicalDescriptions":[
+
+    ],
+    "languages":[
+
+    ],
+    "notes":[
+
+    ],
+    "discoverySuppress":false,
+    "statisticalCodeIds":[
+
+    ],
+    "metadata":{
+      "createdDate":"2020-10-30T11:01:55.690+00:00",
+      "updatedDate":"2020-10-30T11:01:55.690+00:00"
+    },
+    "holdingsRecords2":[
+
+    ],
+    "natureOfContentTermIds":[
+
+    ]
+  },
+  "holdings":[
+    {
+      "id":"67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+      "hrid":"hold000000000007",
+      "formerIds":[
+
+      ],
+      "instanceId":"a89eccf0-57a6-495e-898d-32b9b2210f2f",
+      "permanentLocationId":"f34d27c6-a8eb-461b-acd6-5dea81771e70",
+      "electronicAccess":[
+
+      ],
+      "callNumber":"D15.H63 A3 2002",
+      "notes":[
+
+      ],
+      "holdingsStatements":[
+        {
+          "statement":"Line 1b"
+        },
+        {
+          "statement":"Line 2b"
+        }
+      ],
+      "holdingsStatementsForIndexes":[
+
+      ],
+      "holdingsStatementsForSupplements":[
+
+      ],
+      "statisticalCodeIds":[
+
+      ],
+      "holdingsItems":[
+
+      ],
+      "bareHoldingsItems":[
+
+      ],
+      "metadata":{
+        "createdDate":"2020-10-30T11:01:56.103+00:00",
+        "updatedDate":"2020-10-30T11:01:56.103+00:00"
+      },
+      "items":[
+        {
+          "id":"bb5a6689-c008-4c96-8f8f-b666850ee12d",
+          "hrid":"item000000000012",
+          "holdingsRecordId":"67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+          "formerIds":[
+
+          ],
+          "barcode":"326547658598",
+          "effectiveCallNumberComponents":{
+            "callNumber":"D15.H63 A3 2002"
+          },
+          "yearCaption":[
+
+          ],
+          "notes":[
+
+          ],
+          "circulationNotes":[
+
+          ],
+          "status":{
+            "name":"Checked out"
+          },
+          "materialTypeId":"1a54b431-2e4f-452d-9cae-9cee66c9a892",
+          "permanentLoanTypeId":"2b94c631-fca9-4892-a730-03ee529ffe27",
+          "effectiveLocationId":"f34d27c6-a8eb-461b-acd6-5dea81771e70",
+          "electronicAccess":[
+
+          ],
+          "statisticalCodeIds":[
+
+          ],
+          "metadata":{
+            "createdDate":"2020-10-30T11:01:56.483+00:00",
+            "updatedDate":"2020-10-30T11:01:56.483+00:00"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mapping/given_small_instance.json
+++ b/src/test/resources/mapping/given_small_instance.json
@@ -1,0 +1,7 @@
+{
+  "instance":{
+    "id":"a89eccf0-57a6-495e-898d-32b9b2210f2f",
+    "instanceTypeId":"6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+    "hrid":"inst000000000017"
+  }
+}

--- a/src/test/resources/mapping/given_small_instanceHolding.json
+++ b/src/test/resources/mapping/given_small_instanceHolding.json
@@ -3,5 +3,11 @@
     "id":"a89eccf0-57a6-495e-898d-32b9b2210f2f",
     "instanceTypeId":"6312d172-f0cf-40f6-b27d-9fa8feaf332f",
     "hrid":"inst000000000017"
-  }
+  },
+  "holdings":[
+    {
+      "id":"67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+      "permanentLocationId":"f34d27c6-a8eb-461b-acd6-5dea81771e70"
+    }
+  ]
 }

--- a/src/test/resources/mockData/configurations/get_host_configuration_response.json
+++ b/src/test/resources/mockData/configurations/get_host_configuration_response.json
@@ -1,0 +1,30 @@
+{
+  "configs":[
+    {
+      "id":"21a6a3c7-7073-42d9-80c7-06894aa6b2ca",
+      "module":"USERSBL",
+      "configName":"FOLIO host",
+      "code":"FOLIO_HOST",
+      "description":"FOLIO host address for password reset",
+      "default":true,
+      "enabled":true,
+      "value":"https://folio-testing.dev.folio.org",
+      "metadata":{
+        "createdDate":"2020-11-23T03:30:55.933+00:00",
+        "createdByUserId":"f40d6d27-8af3-5718-9eb1-5046622e5f8c",
+        "updatedDate":"2020-11-23T03:30:55.933+00:00",
+        "updatedByUserId":"f40d6d27-8af3-5718-9eb1-5046622e5f8c"
+      }
+    }
+  ],
+  "totalRecords":1,
+  "resultInfo":{
+    "totalRecords":1,
+    "facets":[
+
+    ],
+    "diagnostics":[
+
+    ]
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-262

## Purpose
Create a link to the inventory record if the export fails


## Approach
Get host from mod config, created a new field inventoryRecordLink  in the affected record.
Build proper affected record instead of instance is always at the top:
if instance record affected, no related holdings and items, if holding - related instance is present, if item - related holding and instance is present.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
