### PR TITLE
MODINVSTOR-626 Update interface for bulk endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -79,8 +79,8 @@
       "version": "1.0"
     },
     {
-      "id": "instance-bulk",
-      "version": "0.1"
+      "id": "record-bulk",
+      "version": "1.0"
     }
   ],
   "provides": [
@@ -183,7 +183,7 @@
             "data-export.file-definitions.upload.post"
           ],
           "modulePermissions": [
-            "inventory-storage.instance-bulk.ids.get"
+            "inventory-storage.record-bulk.ids.get"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -79,7 +79,7 @@
       "version": "1.0"
     },
     {
-      "id": "record-bulk",
+      "id": "inventory-record-bulk",
       "version": "1.0"
     }
   ],

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -13,7 +13,7 @@ import static org.folio.util.ExternalPathResolver.HOLDING;
 import static org.folio.util.ExternalPathResolver.HOLDING_NOTE_TYPES;
 import static org.folio.util.ExternalPathResolver.IDENTIFIER_TYPES;
 import static org.folio.util.ExternalPathResolver.INSTANCE;
-import static org.folio.util.ExternalPathResolver.INSTANCE_BULK_IDS;
+import static org.folio.util.ExternalPathResolver.RECORD_BULK_IDS;
 import static org.folio.util.ExternalPathResolver.INSTANCE_FORMATS;
 import static org.folio.util.ExternalPathResolver.INSTANCE_TYPES;
 import static org.folio.util.ExternalPathResolver.INSTITUTIONS;
@@ -75,7 +75,7 @@ public class InventoryClient {
     if (StringUtils.isEmpty(query)) {
       return Optional.empty();
     }
-    String endpoint = format(resourcesPathWithPrefix(INSTANCE_BULK_IDS), params.getOkapiUrl()) + QUERY + StringUtil.urlEncode(query);
+    String endpoint = format(resourcesPathWithPrefix(RECORD_BULK_IDS), params.getOkapiUrl()) + QUERY + StringUtil.urlEncode(query);
     try {
       return Optional.of(ClientUtil.getRequest(params, endpoint));
     } catch (HttpClientException e) {

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -33,7 +33,7 @@ public class ExternalPathResolver {
   public static final String HOLDING = "holding";
   public static final String ITEM = "item";
   public static final String CONFIGURATIONS = "configurations";
-  public static final String INSTANCE_BULK_IDS = "bulkIds";
+  public static final String RECORD_BULK_IDS = "bulkIds";
 
 
   private static final Map<String, String> EXTERNAL_APIS;
@@ -64,7 +64,7 @@ public class ExternalPathResolver {
     apis.put(ISSUANCE_MODES, "/modes-of-issuance");
     apis.put(HOLDING_NOTE_TYPES, "/holdings-note-types");
     apis.put(ITEM_NOTE_TYPES, "/item-note-types");
-    apis.put(INSTANCE_BULK_IDS, "/record-bulk/ids");
+    apis.put(RECORD_BULK_IDS, "/record-bulk/ids");
     apis.put(USERS, "/users");
     apis.put(CONFIGURATIONS, "/configurations/entries");
 

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -64,7 +64,7 @@ public class ExternalPathResolver {
     apis.put(ISSUANCE_MODES, "/modes-of-issuance");
     apis.put(HOLDING_NOTE_TYPES, "/holdings-note-types");
     apis.put(ITEM_NOTE_TYPES, "/item-note-types");
-    apis.put(INSTANCE_BULK_IDS, "/instance-bulk/ids");
+    apis.put(INSTANCE_BULK_IDS, "/record-bulk/ids");
     apis.put(USERS, "/users");
     apis.put(CONFIGURATIONS, "/configurations/entries");
 

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -137,7 +137,7 @@ public class MockServer {
     router.get(resourcesPath(HOLDING)).handler(ctx -> handleGetHoldingRecord(ctx));
     router.get(resourcesPath(ITEM)).handler(ctx -> handleGetItemRecord(ctx));
     router.get(resourcesPath(CONFIGURATIONS)).handler(ctx -> handleGetConfigurations(ctx));
-    router.get(resourcesPath(INSTANCE_BULK_IDS)).handler(ctx -> handleGetInstanceBulkIds(ctx));
+    router.get(resourcesPath(RECORD_BULK_IDS)).handler(ctx -> handleGetInstanceBulkIds(ctx));
     return router;
   }
 
@@ -481,11 +481,11 @@ public class MockServer {
       JsonObject bulkIds;
       if (ctx.request().getParam("query").contains("(languages=\"eng\")")) {
         bulkIds = new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH));
-        addServerRqRsData(HttpMethod.GET, INSTANCE_BULK_IDS, bulkIds);
+        addServerRqRsData(HttpMethod.GET, RECORD_BULK_IDS, bulkIds);
         serverResponse(ctx, 200, APPLICATION_JSON, bulkIds.encodePrettily());
       } else {
         bulkIds = new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_MOCK_DATA_PATH));
-        addServerRqRsData(HttpMethod.GET, INSTANCE_BULK_IDS, bulkIds);
+        addServerRqRsData(HttpMethod.GET, RECORD_BULK_IDS, bulkIds);
         serverResponse(ctx, 200, APPLICATION_JSON, bulkIds.encodePrettily());
       }
     } catch (IOException e) {


### PR DESCRIPTION

## Purpose
https://issues.folio.org/browse/MODINVSTOR-626

## Approach
Update interface and uri to use record-bulk endpoint instead of instance-bulk.

#### TODOS and Open Questions
This PR should be merged together with https://github.com/folio-org/mod-inventory-storage/pull/556 and https://issues.folio.org/browse/UIIN-1368
