### PR TITLE
MDEXP-351 Add check to not store MARC record in file if data is empty

### DIFF
--- a/src/main/java/org/folio/service/export/LocalFileSystemExportService.java
+++ b/src/main/java/org/folio/service/export/LocalFileSystemExportService.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Service
@@ -46,7 +47,9 @@ public class LocalFileSystemExportService implements ExportService {
       for (String jsonRecord : jsonRecords) {
         byte[] bytes = convertJsonRecordToMarcRecord(jsonRecord);
         try {
-          fileStorage.saveFileDataBlocking(bytes, fileDefinition);
+          if (isNotEmpty(bytes)) {
+            fileStorage.saveFileDataBlocking(bytes, fileDefinition);
+          }
         } catch (RuntimeException e) {
           LOGGER.error("Error during saving srs record to file with content: {}", jsonRecord);
         }
@@ -78,7 +81,9 @@ public class LocalFileSystemExportService implements ExportService {
       for (String record : inventoryRecords) {
         byte[] bytes = record.getBytes(StandardCharsets.UTF_8);
         try {
-          fileStorage.saveFileDataBlocking(bytes, fileDefinition);
+          if (isNotEmpty(bytes)) {
+            fileStorage.saveFileDataBlocking(bytes, fileDefinition);
+          }
         } catch (RuntimeException e) {
           errorLogService.saveGeneralError(ErrorCode.ERROR_SAVING_RECORD_TO_FILE.getCode(), fileDefinition.getJobExecutionId(), tenantId);
           LOGGER.error("Error during saving inventory record to file with content: {}", record);

--- a/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
+++ b/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
@@ -1,24 +1,10 @@
 package org.folio.service.export;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.vertx.core.json.JsonObject;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.util.Lists;
 import org.folio.TestUtil;
 import org.folio.rest.exceptions.ServiceException;
-import org.folio.rest.jaxrs.model.ErrorLog;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.service.export.storage.ExportStorageService;
 import org.folio.service.file.storage.FileStorage;
@@ -28,15 +14,21 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 @ExtendWith(MockitoExtension.class)
@@ -91,6 +83,29 @@ class ExportServiceUnitTest {
     // then
     Mockito.verify(fileStorage, Mockito.times(1)).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
   }
+
+  @Test
+  void shouldNotStoreFile_whenInventoryRecordIsEmpty() {
+    // given
+    String inventoryRecord = StringUtils.EMPTY;
+    FileDefinition fileDefinition = new FileDefinition();
+    // when
+    exportService.exportInventoryRecords(Collections.singletonList(inventoryRecord), fileDefinition, TENANT);
+    // then
+    Mockito.verify(fileStorage, never()).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
+  }
+
+  @Test
+  void shouldNotStoreFile_whenSRSRecordIsEmpty() {
+    // given
+    String inventoryRecord = StringUtils.EMPTY;
+    FileDefinition fileDefinition = new FileDefinition();
+    // when
+    exportService.exportInventoryRecords(Collections.singletonList(inventoryRecord), fileDefinition, TENANT);
+    // then
+    Mockito.verify(fileStorage, never()).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
+  }
+
 
   @Test
   void shouldPassExportFor_NULL_InventoryRecords() {

--- a/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
+++ b/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
@@ -101,7 +101,7 @@ class ExportServiceUnitTest {
     String inventoryRecord = StringUtils.EMPTY;
     FileDefinition fileDefinition = new FileDefinition();
     // when
-    exportService.exportInventoryRecords(Collections.singletonList(inventoryRecord), fileDefinition, TENANT);
+    exportService.exportSrsRecord(Collections.singletonList(inventoryRecord), fileDefinition);
     // then
     Mockito.verify(fileStorage, never()).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
   }

--- a/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
+++ b/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
@@ -85,7 +85,7 @@ class ExportServiceUnitTest {
   }
 
   @Test
-  void shouldNotStoreFile_whenInventoryRecordIsEmpty() {
+  void shouldNotStoreMarcInFile_whenInventoryRecordIsEmpty() {
     // given
     String inventoryRecord = StringUtils.EMPTY;
     FileDefinition fileDefinition = new FileDefinition();
@@ -96,7 +96,7 @@ class ExportServiceUnitTest {
   }
 
   @Test
-  void shouldNotStoreFile_whenSRSRecordIsEmpty() {
+  void shouldNotStoreMarcInFile_whenSRSRecordIsEmpty() {
     // given
     String inventoryRecord = StringUtils.EMPTY;
     FileDefinition fileDefinition = new FileDefinition();


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MDEXP-351

## Approach
Add check to not store file if data is empty during export inventory||srs records. We will avoid creating a file and storing it in S3
with empty data. 


Related PR: https://github.com/folio-org/generate-marc-utils/pull/29
