### PR TITLE
MDEXP-343 - Fix intermittent unit test failures

### DIFF
--- a/src/test/java/org/folio/rest/impl/StorageCleanupServiceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/StorageCleanupServiceImplTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;

--- a/src/test/java/org/folio/rest/impl/StorageCleanupServiceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/StorageCleanupServiceImplTest.java
@@ -86,10 +86,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-      future.onComplete(ar -> {
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
         context.verify(()->{
           assertTrue(ar.succeeded());
           assertTrue(ar.result());
@@ -98,9 +95,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
           assertFileDefinitionIsRemoved();
           context.completeNow();
         });
-
       });
-      return Promise.promise().future();
     });
   }
 
@@ -117,10 +112,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveFileDefinition1Ar -> {
       return fileDefinitionDao.save(fileDefinition2, TENANT_ID).compose(saveFileDefinition2Ar -> {
-        Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-        // then
-        future.onComplete(ar -> {
+        return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
           context.verify(() -> {
             assertTrue(ar.succeeded());
             assertTrue(ar.result());
@@ -131,9 +123,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
             assertFileDefinitionIsRemoved();
             context.completeNow();
           });
-
         });
-        return Promise.promise().future();
       });
     });
   }
@@ -150,10 +140,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-      future.onComplete(ar -> {
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
         context.verify(() -> {
           assertTrue(ar.succeeded());
           assertTrue(ar.result());
@@ -161,9 +148,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
           assertFileDefinitionIsRemoved();
           context.completeNow();
         });
-
       });
-      return Promise.promise().future();
     });
   }
 
@@ -177,10 +162,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-      future.onComplete(ar -> {
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
         context.verify(() -> {
           assertTrue(ar.succeeded());
           assertTrue(ar.result());
@@ -188,9 +170,7 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
           assertFileDefinitionIsRemoved();
           context.completeNow();
         });
-
       });
-      return Promise.promise().future();
     });
   }
 
@@ -202,18 +182,14 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     //when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-        future.onComplete(ar -> {
-          context.verify(() -> {
-            assertTrue(ar.succeeded());
-            assertTrue(ar.result());
-            assertFileDefinitionIsRemoved();
-            context.completeNow();
-          });
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
+        context.verify(() -> {
+          assertTrue(ar.succeeded());
+          assertTrue(ar.result());
+          assertFileDefinitionIsRemoved();
+          context.completeNow();
         });
-      return Promise.promise().future();
+      });
     });
   }
 
@@ -226,18 +202,14 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-        future.onComplete(ar -> {
-          context.verify(() -> {
-            assertTrue(ar.succeeded());
-            assertFalse(ar.result());
-            assertFileDefinitionIsNotRemoved();
-            context.completeNow();
-          });
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
+        context.verify(() -> {
+          assertTrue(ar.succeeded());
+          assertFalse(ar.result());
+          assertFileDefinitionIsNotRemoved();
+          context.completeNow();
         });
-      return Promise.promise().future();
+      });
     });
   }
 
@@ -250,18 +222,14 @@ class StorageCleanupServiceImplTest extends RestVerticleTestBase {
 
     // when
     fileDefinitionDao.save(fileDefinition1, TENANT_ID).compose(saveAr -> {
-      Future<Boolean> future = storageCleanupService.cleanStorage(okapiConnectionParams);
-
-      // then
-        future.onComplete(ar -> {
-          context.verify(() -> {
-            assertTrue(ar.succeeded());
-            assertFalse(ar.result());
-            assertFileDefinitionIsNotRemoved();
-            context.completeNow();
-          });
+      return storageCleanupService.cleanStorage(okapiConnectionParams).onComplete(ar -> {
+        context.verify(() -> {
+          assertTrue(ar.succeeded());
+          assertFalse(ar.result());
+          assertFileDefinitionIsNotRemoved();
+          context.completeNow();
         });
-      return Promise.promise().future();
+      });
     });
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-343

## Purpose
Randomly failing tests on the StorageCleanupServiceImplTest class

## Approach
- The tests were returning a new future rather than the completed future from the clean storage step
This might be a possible fix as we were not able to replicate the issue consistently




## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
