### PR TITLE
MDEXP-349 Change quick export endpoint to return jobExecution id and hrId, add fileName to request

### DIFF
--- a/ramls/dataExport.raml
+++ b/ramls/dataExport.raml
@@ -14,6 +14,7 @@ types:
   fileDefinition: !include schemas/fileDefinition.json
   exportRequest: !include schemas/exportRequest.json
   quickExportRequest: !include schemas/quickExportRequest.json
+  quickExportResponse: !include schemas/quickExportResponse.json
   jobExecutionCollection: !include schemas/jobExecutionCollection.json
   jobExecution: !include schemas/jobExecution.json
   fileDownload: !include schemas/fileDownload.json
@@ -71,7 +72,12 @@ resourceTypes:
           example:
             value: !include samples/quickExportRequest.sample
       responses:
-        204:
+        200:
+          body:
+            application/json:
+              type: quickExportResponse
+              example:
+                value: !include samples/quickExportResponse.sample
         400:
           description: "Bad request"
           body:

--- a/ramls/samples/quickExportResponse.sample
+++ b/ramls/samples/quickExportResponse.sample
@@ -1,0 +1,4 @@
+{
+   "jobExecutionId":"5696d7aa-3bae-11eb-adc1-0242ac120002",
+   "jobExecutionHrId": 1
+}

--- a/ramls/schemas/quickExportRequest.json
+++ b/ramls/schemas/quickExportRequest.json
@@ -37,6 +37,10 @@
         "ITEM"
       ]
     },
+    "fileName": {
+      "description": "Name of the file to export",
+      "type": "string"
+    },
     "metadata": {
       "description": "Meta information ",
       "type": "object",

--- a/ramls/schemas/quickExportResponse.json
+++ b/ramls/schemas/quickExportResponse.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Quick export response",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "jobExecutionId": {
+      "description": "UUID of the job execution, that is used for quick export",
+      "type": "string"
+    },
+    "jobExecutionHrId": {
+      "description": "HrId of the job execution, that is used for quick export",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "jobExecutionId",
+    "jobExecutionHrId"
+  ]
+}

--- a/src/main/java/org/folio/rest/impl/DataExportImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImpl.java
@@ -13,6 +13,7 @@ import org.folio.rest.jaxrs.model.ExportRequest;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.QuickExportRequest;
+import org.folio.rest.jaxrs.model.QuickExportResponse;
 import org.folio.rest.jaxrs.resource.DataExport;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.file.cleanup.StorageCleanupService;
@@ -112,7 +113,9 @@ public class DataExportImpl implements DataExport {
                       .onSuccess(updatedJobExecution -> {
                         inputDataManager.init(JsonObject.mapFrom(buildExportRequest(requestFileDefinition.getId(), jobProfile.getId(), entity)), JsonObject.mapFrom(requestFileDefinition), JsonObject.mapFrom(mappingProfile), JsonObject.mapFrom(updatedJobExecution), okapiHeaders);
                         succeededFuture()
-                          .map(PostDataExportExportResponse.respond204())
+                          .map(PostDataExportQuickExportResponse.respond200WithApplicationJson(new QuickExportResponse()
+                            .withJobExecutionId(jobExecution.getId())
+                            .withJobExecutionHrId(jobExecution.getHrId())))
                           .map(Response.class::cast)
                           .onComplete(asyncResultHandler);
                       }).onFailure(ar -> failToFetchObjectHelper(ar.getMessage(), asyncResultHandler)))
@@ -184,7 +187,7 @@ public class DataExportImpl implements DataExport {
 
   private Future<FileDefinition> getFileDefinitionForQuickExport(QuickExportRequest request, String jobProfileId, OkapiConnectionParams params, Handler<AsyncResult<Response>> asyncResultHandler) {
     Promise<FileDefinition> promise = Promise.promise();
-    fileDefinitionService.prepareFileDefinitionForQuickExport(request.getType(), jobProfileId, tenantId)
+    fileDefinitionService.prepareFileDefinitionForQuickExport(request, jobProfileId, tenantId)
       .onSuccess(fileDefinition -> fileUploadService.uploadFileDependsOnTypeForQuickExport(request, fileDefinition, params)
         .onSuccess(uploadedFileDefinition -> fileUploadService.completeUploading(uploadedFileDefinition, tenantId))
         .onSuccess(promise::complete)

--- a/src/main/java/org/folio/service/file/definition/FileDefinitionService.java
+++ b/src/main/java/org/folio/service/file/definition/FileDefinitionService.java
@@ -36,10 +36,10 @@ public interface FileDefinitionService {
   /**
    * Create {@link FileDefinition} with related jobExecution
    *
-   * @param type     type from {@link QuickExportRequest}
+   * @param request  {@link QuickExportRequest}
    * @param tenantId tenant id
    * @return future with {@link FileDefinition}
    */
-  Future<FileDefinition> prepareFileDefinitionForQuickExport(QuickExportRequest.Type type, String jobProfileId, String tenantId);
+  Future<FileDefinition> prepareFileDefinitionForQuickExport(QuickExportRequest request, String jobProfileId, String tenantId);
 
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MDEXP-349

## Approach
1. Return a 200 response that includes the jobExecutionId and jobExecution.hrid in the body;
2.  Add an optional `fileName` key to the request body. If fileName is not present, the default  **quick-export-HRID** name will be used
