### PR TITLE
MDEXP-389 Release 4.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 04/02/2021 v4.0.1 - Released
+This bugfix release includes fix for inconsistent results when holdings and items data incorrectly appended to the srs record
+in MARC file.
+
+[Full Changelog](https://github.com/folio-org/mod-data-export/compare/v4.0.0...v4.0.1)
+
+### Bug Fixes
+* [MDEXP-385](https://issues.folio.org/browse/MDEXP-385) - Holdings and items data incorrectly appended to the srs record
+
 ## 03/12/2020 v4.0.0 Released
  Major version release which includes below features :
  * allow a user to append holdings and item data with MARC bib record when the user wants to export the record from SRS

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.6"
+      "version": "7.7"
     },
     {
       "id": "holdings-storage",

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>generate-marc-utils</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.1.1</version>
       <type>jar</type>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>4.0.1</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -514,7 +514,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>v4.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.0.1</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -514,7 +514,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v4.0.1</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-389
## Purpose
This bugfix release includes fix for inconsistent results when holdings and items data incorrectly appended to the srs record
in MARC file.

[Full Changelog](https://github.com/folio-org/mod-data-export/compare/v4.0.0...v4.0.1)

### Bug Fixes
* [MDEXP-385](https://issues.folio.org/browse/MDEXP-385) - Holdings and items data incorrectly appended to the srs record
