### PR TITLE
MDEXP-403: Inventory interface versions optimistic locking

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,15 +12,15 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.7"
+      "version": "7.7 8.0"
     },
     {
       "id": "holdings-storage",
-      "version": "4.5"
+      "version": "4.5 5.0"
     },
     {
       "id": "item-storage",
-      "version": "8.9"
+      "version": "8.9 9.0"
     },
     {
       "id": "nature-of-content-terms",

--- a/src/test/resources/mockData/inventory/get_instance_response_in000005.json
+++ b/src/test/resources/mockData/inventory/get_instance_response_in000005.json
@@ -3,6 +3,7 @@
     {
       "@context": "http://localhost:9130/inventory/instances/context",
       "id": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
+      "_version": 3,
       "hrid": "in000005",
       "source": "MARC",
       "title": "Bridget Jones's Baby: the diaries",

--- a/src/test/resources/mockData/inventory/holdings_in000005.json
+++ b/src/test/resources/mockData/inventory/holdings_in000005.json
@@ -2,6 +2,7 @@
   "holdingsRecords": [
     {
       "id": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61",
+      "_version": 4,
       "hrid": "hold000000000004",
       "formerIds": [],
       "instanceId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
@@ -22,6 +23,7 @@
     },
     {
       "id": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
+      "_version": 4,
       "hrid": "hold000000000005",
       "formerIds": [],
       "instanceId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",

--- a/src/test/resources/mockData/inventory/holdings_in00041.json
+++ b/src/test/resources/mockData/inventory/holdings_in00041.json
@@ -2,6 +2,7 @@
     "holdingsRecords": [
         {
             "id": "68872d8a-bf16-420b-829f-206da38f6c10",
+            "_version": 4,
             "hrid": "hold000000000008",
             "formerIds": [],
             "instanceId": "ae573875-fbc8-40e7-bda7-0ac283354226",
@@ -40,6 +41,7 @@
         },
         {
             "id": "c9dd55da-7f48-478b-982c-a527b7cf9ec3",
+            "_version": 4,
             "hrid": "ho00000000004",
             "formerIds": [],
             "instanceId": "ae573875-fbc8-40e7-bda7-0ac283354226",

--- a/src/test/resources/mockData/inventory/items_in000005.json
+++ b/src/test/resources/mockData/inventory/items_in000005.json
@@ -1,6 +1,7 @@
 {
   "items" : [ {
     "id" : "1b6d3338-186e-4e35-9e75-1b886b0da53e",
+    "_version": 5,
     "status" : {
       "name" : "Checked out"
     },
@@ -57,6 +58,7 @@
     }
   }, {
     "id" : "4428a37c-8bae-4f0d-865d-970d83d5ad55",
+    "_version": 5,
     "status" : {
       "name" : "Available"
     },

--- a/src/test/resources/mockData/inventory/items_in00041.json
+++ b/src/test/resources/mockData/inventory/items_in00041.json
@@ -1,6 +1,7 @@
 {
   "items" : [ {
     "id" : "744a66ec-b801-46cd-af8d-b730eac95d3a",
+    "_version": 5,
     "status" : {
       "name" : "Checked out"
     },
@@ -57,6 +58,7 @@
     }
   }, {
     "id" : "7d7b713f-1323-46d2-84a1-e23bae21093a",
+    "_version": 5,
     "status" : {
       "name" : "Available"
     },


### PR DESCRIPTION
Allow additional versions for required inventory interfaces:

* instance-storage 8.0
* holdings-storage 4.0
* item-storage 9.0

They add the `_version` property for optimistic locking.

mod-data-export only uses GET APIs from inventory.
No mod-data-export interfaces are changed.

Unit tests are extended to show that mod-data-export
can process the `_version` property.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [x] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?