### PR TITLE
MDEXP-402: Migration Script does not handle all cases

### DIFF
--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -11,4 +11,4 @@ SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 
 WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
 AND jsonb -> 'progress' -> 'exported' IS NOT NULL
 AND jsonb -> 'progress' -> 'total' IS NULL
-AND jsonb -> 'progress' -> 'failed' IS NULL
+AND jsonb -> 'progress' -> 'failed' IS NULL;

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -2,11 +2,11 @@ UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb #- '{progress, total}', '{progress, total}', to_jsonb((jsonb -> 'progress' ->> 'total')::int))
 WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';
 
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
 WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
 
-UPDATE diku_mod_data_export.job_executions
+UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
 WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
 AND jsonb -> 'progress' -> 'exported' IS NOT NULL

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -5,3 +5,10 @@ WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';
 UPDATE diku_mod_data_export.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
 WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
+
+UPDATE diku_mod_data_export.job_executions
+SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
+WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
+AND jsonb -> 'progress' -> 'exported' IS NOT NULL
+AND jsonb -> 'progress' -> 'total' IS NULL
+AND jsonb -> 'progress' -> 'failed' IS NULL

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -1,14 +1,7 @@
-UPDATE diku_mod_data_export.job_executions
-SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
-WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
-
-UPDATE diku_mod_data_export.job_executions
-SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
-WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
-AND jsonb -> 'progress' -> 'exported' IS NOT NULL
-AND jsonb -> 'progress' -> 'total' IS NULL
-AND jsonb -> 'progress' -> 'failed' IS NULL
-
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb #- '{progress, total}', '{progress, total}', to_jsonb((jsonb -> 'progress' ->> 'total')::int))
 WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';
+
+UPDATE diku_mod_data_export.job_executions
+SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
+WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -1,3 +1,14 @@
+UPDATE diku_mod_data_export.job_executions
+SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
+WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
+
+UPDATE diku_mod_data_export.job_executions
+SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
+WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
+AND jsonb -> 'progress' -> 'exported' IS NOT NULL
+AND jsonb -> 'progress' -> 'total' IS NULL
+AND jsonb -> 'progress' -> 'failed' IS NULL
+
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb #- '{progress, total}', '{progress, total}', to_jsonb((jsonb -> 'progress' ->> 'total')::int))
-WHERE jsonb -> 'progress' IS NOT NULL;
+WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -5,10 +5,3 @@ WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';
 UPDATE diku_mod_data_export.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)
 WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
-
-UPDATE diku_mod_data_export.job_executions
-SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
-WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
-AND jsonb -> 'progress' -> 'exported' IS NOT NULL
-AND jsonb -> 'progress' -> 'total' IS NULL
-AND jsonb -> 'progress' -> 'failed' IS NULL

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -7,7 +7,7 @@ SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported"
 WHERE jsonb -> 'progress' IS NULL OR jsonb -> 'progress' = '{}';
 
 UPDATE ${myuniversity}_${mymodule}.job_executions
-SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported','failed',0,'exported', jsonb -> 'progress' -> 'exported'))
+SET jsonb = jsonb_set(jsonb, '{progress}', jsonb_build_object('total', jsonb -> 'progress' -> 'exported', 'failed', 0, 'exported', jsonb -> 'progress' -> 'exported'))
 WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}'
 AND jsonb -> 'progress' -> 'exported' IS NOT NULL
 AND jsonb -> 'progress' -> 'total' IS NULL


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-402

### PURPOSE
Enhance migration script with additional checks that nested 'progress' object is not empty and populate existed empty 'progress' objects with 0 values for all possible nested fields like total, failed, and exported. Cover the case where only the 'exported' field is presented and populate such 'progress' objects with total field = exported field value and failed = 0.