### PR TITLE
MDEXP-402: Migration Script does not handle all cases

### DIFF
--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -1,6 +1,6 @@
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb #- '{progress, total}', '{progress, total}', to_jsonb((jsonb -> 'progress' ->> 'total')::int))
-WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}';
+WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}' AND jsonb -> 'progress' -> 'total' IS NOT NULL;;
 
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)

--- a/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/change_progress_total_data_type.sql
@@ -1,6 +1,6 @@
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb #- '{progress, total}', '{progress, total}', to_jsonb((jsonb -> 'progress' ->> 'total')::int))
-WHERE jsonb -> 'progress' IS NOT NULL AND jsonb -> 'progress' <> '{}' AND jsonb -> 'progress' -> 'total' IS NOT NULL;;
+WHERE jsonb -> 'progress' -> 'total' IS NOT NULL;;
 
 UPDATE ${myuniversity}_${mymodule}.job_executions
 SET jsonb = jsonb_set(jsonb, '{progress}', '{"total": 0, "failed": 0, "exported": 0}'::jsonb)


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-402

### PURPOSE
Add additional check for empty "total" filed when running scripts and there is a progress object with "exported" field only.

### **Progress objects before running update scripts**
![4000 - all fields and total string BEFORE script](https://user-images.githubusercontent.com/60663044/126181225-fccd1b4a-2382-4c84-a809-01db217eaa3f.PNG)
![0000-string total BEFORE script](https://user-images.githubusercontent.com/60663044/126181232-916bb4d9-6686-48ac-a3e5-6d1fad0ae52a.PNG)
![1000-empty postgres BEFORE script](https://user-images.githubusercontent.com/60663044/126181234-6980c5ee-dca5-4977-b09b-449279829c35.PNG)
![2000- absent progres (null) BEFORE script](https://user-images.githubusercontent.com/60663044/126181235-8d148954-8e31-4159-8608-fd348d1dd347.PNG)
![3000- only exported field BEFORE script](https://user-images.githubusercontent.com/60663044/126181236-3bae8206-41e0-4644-8b40-e672e18ff4ac.PNG)

### **Run script**
![script result final](https://user-images.githubusercontent.com/60663044/126181281-7cbf8b73-bd63-4df6-9144-20c96507c7ff.PNG)

### **Progress objects after running update scripts**
![4000 - all fields and total string AFTER script](https://user-images.githubusercontent.com/60663044/126181366-f8c8a471-4ec1-47d8-85ec-bf4ea74a62aa.PNG)
![0000-string total AFTER script](https://user-images.githubusercontent.com/60663044/126181373-e37471a4-493c-42d6-9619-687b08bb6b96.PNG)
![1000-empty postgres AFTER script](https://user-images.githubusercontent.com/60663044/126181374-d69c9eb0-3eb1-4aa6-86d1-cb4b4511fe21.PNG)
![2000- absent progres (null) AFTER script](https://user-images.githubusercontent.com/60663044/126181377-3525e183-395a-4bd3-901f-181bf757a74a.PNG)
![3000- only exported field AFTER script](https://user-images.githubusercontent.com/60663044/126181379-5e4af59d-810b-497d-acc7-2340de53c83b.PNG)

