### PR TITLE
MDEXP-394: Memory leaks in mod-data-export

### DIFF
--- a/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
+++ b/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
@@ -73,7 +73,7 @@ public class LocalFileSystemStorage implements FileStorage {
         blockingFuture.complete();
       }
       promise.complete(fileDefinition);
-    }, null);
+    });
     return promise.future();
   }
 

--- a/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
+++ b/src/main/java/org/folio/service/file/storage/LocalFileSystemStorage.java
@@ -51,9 +51,11 @@ public class LocalFileSystemStorage implements FileStorage {
       } catch (Exception e) {
         LOGGER.error("Error during save data to the local system's storage. FileId: {}", fileDefinition.getId(), e);
         promise.fail(e);
+      } finally {
+        blockingFuture.complete();
       }
       promise.complete(fileDefinition);
-    }, null);
+    });
     return promise.future();
   }
 
@@ -67,6 +69,8 @@ public class LocalFileSystemStorage implements FileStorage {
       } catch (Exception e) {
         LOGGER.error("Error during save data to the local system's storage. FileId: {}", fileDefinition.getId(), e);
         promise.fail(e);
+      } finally {
+        blockingFuture.complete();
       }
       promise.complete(fileDefinition);
     }, null);


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-394

### PURPOSE
Try to complete the promise of the blocking code handler. This promise object wasn't completed which may cause objects to stuck in the memory cause they hold by the handler which cannot be finished.