### PR TITLE
MDEXP-422: Gracefully handle MARC records that exceed the size limit

### DIFF
--- a/src/main/java/org/folio/service/export/ExportService.java
+++ b/src/main/java/org/folio/service/export/ExportService.java
@@ -1,5 +1,6 @@
 package org.folio.service.export;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.service.manager.export.ExportPayload;
 
@@ -14,10 +15,10 @@ public interface ExportService {
    * Exports collection of srs records to the destination.
    * Performs converting from json to marc format.
    *
-   * @param jsonRecords    collection of srs records on export
+   * @param marcToExport   collection of srs records on export and count of failed records
    * @param exportPayload  export payload on export
    */
-  void exportSrsRecord(List<String> jsonRecords, ExportPayload exportPayload);
+  void exportSrsRecord(Pair<List<String>, Integer> marcToExport, ExportPayload exportPayload);
 
   /**
    * Exports collection of marc records to the destination.

--- a/src/main/java/org/folio/service/mapping/converter/SrsRecordConverterService.java
+++ b/src/main/java/org/folio/service/mapping/converter/SrsRecordConverterService.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.vertx.core.json.JsonObject;
 import java.util.Collections;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +43,7 @@ public class SrsRecordConverterService extends RecordConverter {
     if (isTransformationRequired(mappingProfile)) {
       return transformSrsRecord(mappingProfile, srsRecords, jobExecutionId, connectionParams);
     } else {
-      return Pair.of(getRecordContent(srsRecords), 0);
+      return MutablePair.of(getRecordContent(srsRecords), 0);
     }
   }
 
@@ -57,7 +58,7 @@ public class SrsRecordConverterService extends RecordConverter {
       marcRecords.add(convert(srsRecord.encode(), mappedFields.getKey()));
       failedCount = failedCount + mappedFields.getValue();
     }
-    return Pair.of(marcRecords, failedCount);
+    return MutablePair.of(marcRecords, failedCount);
   }
 
   private Pair<List<VariableField>, Integer> getMappedFields(MappingProfile mappingProfile, String jobExecutionId,

--- a/src/main/java/org/folio/util/ErrorCode.java
+++ b/src/main/java/org/folio/util/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     errorCodesForUUIDs.add(DATE_PARSE_ERROR_CODE.getCode());
     errorCodesForUUIDs.add(ERROR_FIELDS_MAPPING_INVENTORY_WITH_REASON.getCode());
     errorCodesForUUIDs.add(ERROR_FIELDS_MAPPING_SRS.getCode());
+    errorCodesForUUIDs.add(ERROR_MARC_RECORD_CANNOT_BE_CONVERTED.getCode());
     errorCodesForUUIDs.add(UNDEFINED.getCode());
     return errorCodesForUUIDs;
   }

--- a/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
+++ b/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
@@ -3,6 +3,7 @@ package org.folio.service.export;
 import io.vertx.core.json.JsonObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.assertj.core.util.Lists;
 import org.folio.TestUtil;
@@ -75,7 +76,7 @@ class ExportServiceUnitTest {
     // given
     String response = TestUtil.readFileContentFromResources(RECORDS_RESPONSE_JSON_FILE_PATH);
     String jsonRecord = new JsonObject(response).getJsonArray("sourceRecords").getJsonObject(0).toString();
-    Pair<List<String>, Integer> marcRecordsToExport = Pair.of(Collections.singletonList(jsonRecord), 0);
+    Pair<List<String>, Integer> marcRecordsToExport = MutablePair.of(Collections.singletonList(jsonRecord), 0);
 
     when(fileStorage.saveFileDataBlocking(any(byte[].class), any(FileDefinition.class))).thenReturn(fileDefinition);
     // when
@@ -101,7 +102,7 @@ class ExportServiceUnitTest {
     String stringJson = TestUtil.readFileContentFromResources(INSTANCES_RESPONSE_JSON_FILE_PATH);
     JsonObject instances = new JsonObject(stringJson);
     JsonObject instance = instances.getJsonArray("instances").getJsonObject(0);
-    Pair<List<String>, Integer> marcRecordsToExport = Pair.of(Collections.singletonList(record), 0);
+    Pair<List<String>, Integer> marcRecordsToExport = MutablePair.of(Collections.singletonList(record), 0);
 
     when(inventoryClient.getInstancesByIds(Collections.singletonList(INSTANCE_ID), jobExecutionId, params, 1)).thenReturn(Optional.of(instances));
     //when
@@ -137,7 +138,7 @@ class ExportServiceUnitTest {
   void shouldNotStoreMarcInFile_whenSRSRecordIsEmpty() {
     // given
     String inventoryRecord = StringUtils.EMPTY;
-    Pair<List<String>, Integer> marcRecordsToExport = Pair.of(Collections.singletonList(inventoryRecord), 0);
+    Pair<List<String>, Integer> marcRecordsToExport = MutablePair.of(Collections.singletonList(inventoryRecord), 0);
 
     // when
     exportService.exportSrsRecord(marcRecordsToExport, exportPayload);

--- a/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
+++ b/src/test/java/org/folio/service/export/ExportServiceUnitTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 import static java.util.Collections.emptyList;
 import static org.folio.util.ErrorCode.ERROR_MARC_RECORD_CANNOT_BE_CONVERTED;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,6 +84,7 @@ class ExportServiceUnitTest {
     exportService.exportSrsRecord(marcRecordsToExport, exportPayload);
     // then
     Mockito.verify(fileStorage, Mockito.times(1)).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
+    assertEquals(0, marcRecordsToExport.getValue().intValue());
   }
 
   @Test
@@ -93,6 +95,7 @@ class ExportServiceUnitTest {
     exportService.exportSrsRecord(marcRecordsToExport, exportPayload);
     // then
     Mockito.verify(fileStorage, Mockito.times(0)).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
+    assertEquals(0, marcRecordsToExport.getValue().intValue());
   }
 
   @Test
@@ -109,6 +112,7 @@ class ExportServiceUnitTest {
     exportService.exportSrsRecord(marcRecordsToExport, exportPayload);
     //then
     Mockito.verify(errorLogService, Mockito.times(1)).saveWithAffectedRecord(eq(instance), eq(ERROR_MARC_RECORD_CANNOT_BE_CONVERTED.getCode()), eq(jobExecutionId), any(MarcException.class), eq(params));
+    assertEquals(1, marcRecordsToExport.getValue().intValue());
   }
 
   @Test
@@ -144,6 +148,7 @@ class ExportServiceUnitTest {
     exportService.exportSrsRecord(marcRecordsToExport, exportPayload);
     // then
     Mockito.verify(fileStorage, never()).saveFileDataBlocking(any(byte[].class), any(FileDefinition.class));
+    assertEquals(0, marcRecordsToExport.getValue().intValue());
   }
 
 

--- a/src/test/java/org/folio/service/manager/export/InstanceExportStrategyUnitTest.java
+++ b/src/test/java/org/folio/service/manager/export/InstanceExportStrategyUnitTest.java
@@ -28,6 +28,7 @@ import org.folio.service.mapping.converter.SrsRecordConverterService;
 import org.folio.service.profiles.mappingprofile.MappingProfileService;
 import org.folio.util.ErrorCode;
 import org.folio.util.OkapiConnectionParams;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -106,7 +107,7 @@ class InstanceExportStrategyUnitTest {
     // then
     Mockito.verify(recordLoaderService, Mockito.times(20)).loadMarcRecordsBlocking(anyList(), anyString(), any(OkapiConnectionParams.class));
     Mockito.verify(recordLoaderService, Mockito.times(1)).loadInventoryInstancesBlocking(anyList(), anyString(), any(OkapiConnectionParams.class), eq(LIMIT));
-    Mockito.verify(exportService, Mockito.times(1)).exportSrsRecord(anyList(), any(ExportPayload.class));
+    Mockito.verify(exportService, Mockito.times(1)).exportSrsRecord(any(Pair.class), any(ExportPayload.class));
     Mockito.verify(inventoryRecordService, Mockito.times(1)).transformInventoryRecords(anyList(), anyString(), any(MappingProfile.class), any(OkapiConnectionParams.class));
     Mockito.verify(exportService, Mockito.times(1)).postExport(any(FileDefinition.class), anyString());
     Mockito.verify(errorLogService).populateUUIDsNotFoundErrorLog(anyString(), anyList(), anyString());
@@ -139,7 +140,7 @@ class InstanceExportStrategyUnitTest {
 
     // then
     Mockito.verify(recordLoaderService, Mockito.times(20)).loadMarcRecordsBlocking(anyList(), anyString(), any(OkapiConnectionParams.class));
-    Mockito.verify(exportService, Mockito.times(1)).exportSrsRecord(anyList(), any(ExportPayload.class));
+    Mockito.verify(exportService, Mockito.times(1)).exportSrsRecord(any(Pair.class), any(ExportPayload.class));
     Mockito.verify(errorLogService).saveGeneralError(eq(ErrorCode.DEFAULT_MAPPING_PROFILE_NOT_FOUND.getCode()), anyString(), anyString());
   }
 


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-422

### PURPOSE
During the testing, I noticed that the job status was incorrect when there was a mixed set of records with records that should be exported and records that should fail. As well the failed/exported fields of the job progress were incorrect in the case of mixed records.
Update the unit tests.
The flow will be covered with integration tests in https://github.com/folio-org/folio-integration-tests. Unit tests are not applicable here.

### APPROACH
In order to make the job display a correct status, the ERROR_MARC_RECORD_CANNOT_BE_CONVERTED code was added to the `isSelectedErrorsPresent()` method which tracks the error logs related to the export and if some are presented then the job obtains the COMPLETED WITH ERRORS status instead of the just COMPLETED.

Since we added error handling for marc records that cannot be converted we should take them into account when updating job progress exported/failed field values.
So, the possible flows are as next: 
1) All instances have marc records
2) Instances partially have the marc records
3) No one instance has a marc record.

**In the first case**, we pass the `Pair<List<String>, Integer> marcToExport` to `exportService.exportSrsRecord(marcToExport, exportPayload)` method, in order to update the value of the Pair with a number of the failed records. Further, since there all instances have the underlying srs records, the generateRecordsOnTheFly code is skipped and we update the exportPayload failed records count including the number of the failed marc records that couldn't be mapped for some reason. And thus we track the real number of failed/exported records. In short, when we take an underlying srs record of the instance in order to process it and enrich with the fields that specified within the mapping profile and the record cannot be mapped then such instance cannot be exported and we track the failure in the progress of the job (field "failed").

**In the second case**, we pass the `Pair<List<String>, Integer> marcToExport` to `exportService.exportSrsRecord(marcToExport, exportPayload)` method, in order to update the value of the Pair with a number of failed records. Further, the generateRecordsOnTheFly method is invoked for mapping the remaining instances that haven't underlying srs records and we pass the value of the failed marc records and thus the final value of failed exported will include not only failed instances but the number of failed marc records as well which is correct. 
`exportPayload.setExportedRecordsNumber(srsLoadResult.getUnderlyingMarcRecords().size()`**- failedSrsRecords**` + mappedMarcRecords.size() - failedRecordsCount);`

**In the third case**, the flow stays as it was before but we pass the 0 as the value for failed marc records number since we didn't process any of them and all the records should be generated relying on the instance/holding/item data depending from the mapping profile transformations.

![correct status and exported,failed fields](https://user-images.githubusercontent.com/60663044/128707823-9cf8a2d5-5046-4969-ba84-02008e2847d5.PNG)
### 1 - valid record export
### 2 - mixed records export
### 3 - invalid only record export
