### PR TITLE
MDEXP-425: When a highly inefficient query is done, vertx main thread is blocked 

### DIFF
--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -98,7 +98,9 @@ public class InventoryClient {
     request.putHeader(OKAPI_HEADER_TENANT, params.getTenantId());
     request.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     request.putHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-    request.ssl(true);
+    if (params.getOkapiUrl().contains("https")) {
+      request.ssl(true);
+    }
     request.send(res -> {
       if (res.failed()) {
         logError(res.cause(), params);

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -117,7 +117,7 @@ public class InventoryClient {
           try {
             JsonObject instances = response.bodyAsJsonObject();
             if (instances != null) {
-              promise.complete(Optional.of(response.bodyAsJsonObject()));
+              promise.complete(Optional.of(instances));
             } else {
               logError(new IllegalStateException(format(ERROR_MESSAGE_EMPTY_BODY, endpoint)), params);
               promise.complete(Optional.empty());

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,6 +1,10 @@
 package org.folio.config;
 
 import com.google.common.collect.ImmutableMap;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
 import org.folio.service.logs.AffectedRecordBuilder;
 import org.folio.service.logs.AffectedRecordHoldingBuilder;
 import org.folio.service.logs.AffectedRecordInstanceBuilder;
@@ -21,6 +25,8 @@ import java.util.Map;
   "org.folio.rest.impl"})
 public class ApplicationConfig {
 
+  private static final int REQUEST_TIMEOUT_TWO_HOURS = 3600000;
+
   @Bean
   @Qualifier("affectedRecordBuilders")
   public Map<String, AffectedRecordBuilder> getBuilders(@Autowired AffectedRecordInstanceBuilder affectedRecordInstanceBuilder,
@@ -32,4 +38,13 @@ public class ApplicationConfig {
       .put(AffectedRecordItemBuilder.class.getName(), affectedRecordItemBuilder)
       .build();
   }
+
+  @Bean
+  public WebClient getWebClient(@Autowired Vertx vertx) {
+    WebClientOptions webClientOptions = new WebClientOptions()
+      .setKeepAliveTimeout(REQUEST_TIMEOUT_TWO_HOURS)
+      .setConnectTimeout(REQUEST_TIMEOUT_TWO_HOURS);
+    return WebClient.create(vertx, webClientOptions);
+  }
+
 }

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -25,7 +25,7 @@ import java.util.Map;
   "org.folio.rest.impl"})
 public class ApplicationConfig {
 
-  private static final int REQUEST_TIMEOUT_TWO_HOURS = 3600000;
+  private static final int REQUEST_TIMEOUT_ONE_HOURS = 3600000;
 
   @Bean
   @Qualifier("affectedRecordBuilders")
@@ -42,8 +42,8 @@ public class ApplicationConfig {
   @Bean
   public WebClient getWebClient(@Autowired Vertx vertx) {
     WebClientOptions webClientOptions = new WebClientOptions()
-      .setKeepAliveTimeout(REQUEST_TIMEOUT_TWO_HOURS)
-      .setConnectTimeout(REQUEST_TIMEOUT_TWO_HOURS);
+      .setKeepAliveTimeout(REQUEST_TIMEOUT_ONE_HOURS)
+      .setConnectTimeout(REQUEST_TIMEOUT_ONE_HOURS);
     return WebClient.create(vertx, webClientOptions);
   }
 

--- a/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/src/main/java/org/folio/config/ApplicationConfig.java
@@ -25,7 +25,7 @@ import java.util.Map;
   "org.folio.rest.impl"})
 public class ApplicationConfig {
 
-  private static final int REQUEST_TIMEOUT_ONE_HOURS = 3600000;
+  private static final int REQUEST_TIMEOUT_ONE_HOUR = 3600000;
 
   @Bean
   @Qualifier("affectedRecordBuilders")
@@ -42,8 +42,8 @@ public class ApplicationConfig {
   @Bean
   public WebClient getWebClient(@Autowired Vertx vertx) {
     WebClientOptions webClientOptions = new WebClientOptions()
-      .setKeepAliveTimeout(REQUEST_TIMEOUT_ONE_HOURS)
-      .setConnectTimeout(REQUEST_TIMEOUT_ONE_HOURS);
+      .setKeepAliveTimeout(REQUEST_TIMEOUT_ONE_HOUR)
+      .setConnectTimeout(REQUEST_TIMEOUT_ONE_HOUR);
     return WebClient.create(vertx, webClientOptions);
   }
 

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -36,8 +36,6 @@ import static org.folio.rest.jaxrs.model.FileDefinition.Status.NEW;
 @Service
 public class FileUploadServiceImpl implements FileUploadService {
 
-  private static final int WORKER_EXECUTE_TIME_IN_HOURS = 2;
-
   @Autowired
   private FileDefinitionService fileDefinitionService;
   @Autowired

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -1,13 +1,9 @@
 package org.folio.service.file.upload;
 
-import io.vertx.config.ConfigRetriever;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.clients.InventoryClient;
@@ -26,11 +22,11 @@ import org.folio.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 import static org.folio.rest.jaxrs.model.FileDefinition.Status.COMPLETED;
 import static org.folio.rest.jaxrs.model.FileDefinition.Status.ERROR;

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -3,6 +3,8 @@ package org.folio.rest.impl;
 import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 import java.util.UUID;
 
@@ -12,10 +14,10 @@ import org.folio.config.ApplicationConfig;
 import org.folio.spring.SpringContextUtil;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -27,6 +29,7 @@ import java.util.Optional;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(VertxExtension.class)
 @RunWith(VertxUnitRunner.class)
 class InventoryClientTest extends RestVerticleTestBase {
   private static final int LIMIT = 20;
@@ -59,7 +62,7 @@ class InventoryClientTest extends RestVerticleTestBase {
   }
 
   @Test
-  void shouldRetrieveInstanceBulkUUIDS() {
+  void shouldRetrieveInstanceBulkUUIDS(VertxTestContext testContext) {
     // given
     String query = "cql query";
     // when
@@ -67,29 +70,56 @@ class InventoryClientTest extends RestVerticleTestBase {
       //then
       Assert.assertTrue(inventoryResponse.isPresent());
       Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
-    }).onFailure(Assertions::fail);
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
   }
 
   @Test
-  void shouldReturnEmptyOptional_whenErrorOccurredWhileRequestingInstanceBulkUUIDS() {
+  void shouldReturnEmptyOptional_whenErrorOccurredWhileRequestingInstanceBulkUUIDS(VertxTestContext testContext) {
     // given
     String query = "error from client";
     // when
     inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then
       Assert.assertTrue(inventoryResponse.isEmpty());
-    }).onFailure(Assertions::fail);
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
   }
 
   @Test
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned() {
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext) {
     // given
     String query = "inventory 500";
     // when
     inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then
       Assert.assertTrue(inventoryResponse.isEmpty());
-    }).onFailure(Assertions::fail);
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndEmptyJsonBodyReturned(VertxTestContext testContext) {
+    // given
+    String query = "empty json response";
+    // when
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidJsonBodyReturned(VertxTestContext testContext) {
+    // given
+    String query = "invalid json returned";
+    // when
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.junit.jupiter.api.Assertions.fail;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @RunWith(VertxUnitRunner.class)
@@ -75,6 +74,17 @@ class InventoryClientTest extends RestVerticleTestBase {
   void shouldReturnEmptyOptional_whenErrorOccurredWhileRequestingInstanceBulkUUIDS() {
     // given
     String query = "error from client";
+    // when
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+    }).onFailure(Assertions::fail);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned() {
+    // given
+    String query = "inventory 500";
     // when
     inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -12,6 +12,7 @@ import org.folio.config.ApplicationConfig;
 import org.folio.spring.SpringContextUtil;
 import org.folio.util.OkapiConnectionParams;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -67,10 +68,7 @@ class InventoryClientTest extends RestVerticleTestBase {
       //then
       Assert.assertTrue(inventoryResponse.isPresent());
       Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
-    }).onFailure(throwable -> {
-      System.out.println("kek");
-      fail(throwable);
-    });
+    }).onFailure(Assertions::fail);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @RunWith(VertxUnitRunner.class)
 class InventoryClientTest extends RestVerticleTestBase {
@@ -49,16 +50,16 @@ class InventoryClientTest extends RestVerticleTestBase {
   }
 
   @Test
-  void shouldRetrieveInstanceBulkUUIDS(VertxTestContext testContext) {
+  void shouldRetrieveInstanceBulkUUIDS() {
     // given
     InventoryClient inventoryClient = new InventoryClient();
     String query = "cql query";
     // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onComplete(testContext.succeeding(inventoryResponse -> {
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then
       Assert.assertTrue(inventoryResponse.isPresent());
       Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
-    }));
+    }).onFailure(fail());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -72,6 +72,17 @@ class InventoryClientTest extends RestVerticleTestBase {
   }
 
   @Test
+  void shouldReturnEmptyOptional_whenErrorOccurredWhileRequestingInstanceBulkUUIDS() {
+    // given
+    String query = "error from client";
+    // when
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+    }).onFailure(Assertions::fail);
+  }
+
+  @Test
   void shouldRetrieveNatureOfContentTerms() {
     // when
     Map<String, JsonObject> natureOfContentTerms = inventoryClient.getNatureOfContentTerms(JOB_EXECUTION_ID, okapiConnectionParams);

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -75,18 +75,6 @@ class InventoryClientTest extends RestVerticleTestBase {
   }
 
   @Test
-  void shouldReturnEmptyOptional_whenErrorOccurredWhileRequestingInstanceBulkUUIDS(VertxTestContext testContext) {
-    // given
-    String query = "error from client";
-    // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isEmpty());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
-
-  @Test
   void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext) {
     // given
     String query = "inventory 500";

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -2,6 +2,8 @@ package org.folio.rest.impl;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
+
 import java.util.UUID;
 
 import org.apache.commons.collections4.map.HashedMap;
@@ -47,15 +49,16 @@ class InventoryClientTest extends RestVerticleTestBase {
   }
 
   @Test
-  void shouldRetrieveInstanceBulkUUIDS() {
+  void shouldRetrieveInstanceBulkUUIDS(VertxTestContext testContext) {
     // given
     InventoryClient inventoryClient = new InventoryClient();
     String query = "cql query";
     // when
-    Optional<JsonObject> inventoryResponse = inventoryClient.getInstancesBulkUUIDs(query, okapiConnectionParams);
-    // then
-    Assert.assertTrue(inventoryResponse.isPresent());
-    Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
+    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onComplete(testContext.succeeding(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isPresent());
+      Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
+    }));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -404,6 +404,10 @@ public class MockServer {
         throw new IllegalStateException("client exception");
       } else if (ctx.request().getParam("query").contains("inventory 500")) {
         mockResponseWith500Status(ctx);
+      } else if (ctx.request().getParam("query").contains("empty json response")) {
+        ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end();
+      } else if (ctx.request().getParam("query").contains("invalid json returned")) {
+        ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end("{qwe");
       } else {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
       }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -400,6 +400,8 @@ public class MockServer {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("(languages=\"uk\")")) {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_WITH_RANDOM, RECORD_BULK_IDS, ctx);
+      } else if (ctx.request().getParam("query").contains("error from client")) {
+        throw new IllegalStateException("client exception");
       } else {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
       }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -400,8 +400,6 @@ public class MockServer {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("(languages=\"uk\")")) {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_WITH_RANDOM, RECORD_BULK_IDS, ctx);
-      } else if (ctx.request().getParam("query").contains("error from client")) {
-        throw new IllegalStateException("client exception");
       } else if (ctx.request().getParam("query").contains("inventory 500")) {
         mockResponseWith500Status(ctx);
       } else if (ctx.request().getParam("query").contains("empty json response")) {

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -402,6 +402,8 @@ public class MockServer {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_WITH_RANDOM, RECORD_BULK_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("error from client")) {
         throw new IllegalStateException("client exception");
+      } else if (ctx.request().getParam("query").contains("inventory 500")) {
+        mockResponseWith500Status(ctx);
       } else {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
       }

--- a/src/test/java/org/folio/service/file/upload/FileUploadServiceUnitTest.java
+++ b/src/test/java/org/folio/service/file/upload/FileUploadServiceUnitTest.java
@@ -149,6 +149,7 @@ class FileUploadServiceUnitTest {
     when(jobExecutionService.getById(JOB_EXECUTION_ID, TENANT_ID)).thenReturn(succeededFuture());
     when(fileDefinitionService.update(any(FileDefinition.class), anyString())).thenReturn(succeededFuture(inProgressDef))
       .thenReturn(succeededFuture(completedDef));
+    when(inventoryClient.getInstancesBulkUUIDsAsync(eq("test"), any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(Optional.empty()));
 
     // when
     Future<FileDefinition> fileDefinitionFuture = fileUploadService.uploadFileDependsOnTypeForQuickExport(quickExportRequest, fileDefinition, params);
@@ -182,7 +183,7 @@ class FileUploadServiceUnitTest {
     when(jobExecutionService.update(any(JobExecution.class), eq(TENANT_ID))).thenReturn(succeededFuture(jobExecution));
     when(fileDefinitionService.update(any(FileDefinition.class), anyString())).thenReturn(succeededFuture(inProgressDef))
       .thenReturn(succeededFuture(completedDef));
-    when(inventoryClient.getInstancesBulkUUIDs(anyString(), eq(params))).thenReturn(of(new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH))));
+    when(inventoryClient.getInstancesBulkUUIDsAsync(anyString(), eq(params))).thenReturn(Future.succeededFuture(of(new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH)))));
     when(fileStorage.saveFileDataAsyncCQL(anyList(), any(FileDefinition.class))).thenReturn(succeededFuture(completedDef));
 
     // when


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-425

### PURPOSE

Avoid spamming of ThreadBlockedEception when the inventory request takes more than 60 seconds to be processed.  

### APPROACH

Refactor client to make it async and replace the verx.executeBlocking with a simple call to this new async method form.  
I tested the approach, it works fine.