### PR TITLE
MDEXP-440: Reference data is missing when there are more than 200 entities. 

### DIFF
--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -70,7 +70,7 @@ public class InventoryClient {
   private static final String ERROR_MESSAGE_INVALID_STATUS_CODE = "Exception while calling %s, message: Get invalid response with status: %s";
   private static final String ERROR_MESSAGE_INVALID_BODY = "Exception while calling %s, message: Got invalid response body: %s";
   private static final String ERROR_MESSAGE_EMPTY_BODY = "Exception while calling %s, message: empty body returned.";
-  private static final int REFERENCE_DATA_LIMIT = 200;
+  private static final int REFERENCE_DATA_LIMIT = 1000;
   private static final int HOLDINGS_LIMIT = 1000;
 
   @Autowired


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-440

### PURPOSE
Increase limit param from 200 to 1000 which is a FOLIO default limit param(for instance the setting apps and others use the limit param of 1000 for getting all entities for editing and etc.)

I investigated the history of the value 200 and there are no secrets behind this value. So it can just be increased. 