### PR TITLE
MDEXP-473 - CQL export fails when effective location is included in the cql statement

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -81,6 +81,10 @@
     {
       "id": "inventory-record-bulk",
       "version": "1.0"
+    },
+    {
+      "id": "search",
+      "version": "0.6"
     }
   ],
   "provides": [
@@ -183,7 +187,8 @@
             "data-export.file-definitions.upload.post"
           ],
           "modulePermissions": [
-            "inventory-storage.record-bulk.ids.get"
+            "inventory-storage.record-bulk.ids.get",
+            "search.instances.ids.collection.get"
           ]
         },
         {

--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -6,34 +6,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.service.logs.ErrorLogService;
 import org.folio.util.ErrorCode;
 import org.folio.util.OkapiConnectionParams;
-import org.folio.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
 import static java.lang.String.format;
 import static org.folio.clients.ClientUtil.buildQueryEndpoint;
 import static org.folio.clients.ClientUtil.getRequest;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.util.ExternalPathResolver.ALTERNATIVE_TITLE_TYPES;
 import static org.folio.util.ExternalPathResolver.CALL_NUMBER_TYPES;
 import static org.folio.util.ExternalPathResolver.CAMPUSES;
@@ -54,7 +42,6 @@ import static org.folio.util.ExternalPathResolver.LIBRARIES;
 import static org.folio.util.ExternalPathResolver.LOAN_TYPES;
 import static org.folio.util.ExternalPathResolver.LOCATIONS;
 import static org.folio.util.ExternalPathResolver.MATERIAL_TYPES;
-import static org.folio.util.ExternalPathResolver.RECORD_BULK_IDS;
 import static org.folio.util.ExternalPathResolver.resourcesPathWithPrefix;
 
 @Component
@@ -65,11 +52,6 @@ public class InventoryClient {
   private static final String QUERY_LIMIT_PATTERN = "?query=(%s)&limit=";
   private static final String QUERY_PATTERN_HOLDING = "instanceId==%s";
   private static final String QUERY_PATTERN_ITEM = "holdingsRecordId==%s";
-  private static final String QUERY = "?query=";
-  private static final String ERROR_MESSAGE_INVALID_STATUS_CODE = "Exception while calling %s, message: Get invalid response with status: %s";
-  private static final String ERROR_MESSAGE_INVALID_BODY = "Exception while calling %s, message: Got invalid response body: %s";
-  private static final String ERROR_MESSAGE_EMPTY_BODY = "Exception while calling %s, message: empty body returned.";
-  private static final String BULK_EDIT_HOLDING_QUERY_PREFIX = "?field=instanceId&recordType=HOLDING&imit=10&query=";
   private static final int REFERENCE_DATA_LIMIT = 1000;
   private static final int HOLDINGS_LIMIT = 1000;
 
@@ -87,55 +69,6 @@ public class InventoryClient {
       errorLogService.saveGeneralErrorWithMessageValues(ErrorCode.ERROR_GETTING_INSTANCES_BY_IDS.getCode(), Arrays.asList(exception.getMessage()), jobExecutionId, params.getTenantId());
       return Optional.empty();
     }
-  }
-
-  public Future<Optional<JsonObject>> getInstancesBulkUUIDsAsync(String query, OkapiConnectionParams params) {
-    Promise<Optional<JsonObject>> promise = Promise.promise();
-    if (StringUtils.isEmpty(query)) {
-      promise.complete(Optional.empty());
-      return promise.future();
-    }
-    String endpoint = format(resourcesPathWithPrefix(RECORD_BULK_IDS), params.getOkapiUrl()) + QUERY + StringUtil.urlEncode(query);
-    HttpRequest<Buffer> request = webClient.getAbs(endpoint);
-    request.putHeader(OKAPI_HEADER_TOKEN, params.getToken());
-    request.putHeader(OKAPI_HEADER_TENANT, params.getTenantId());
-    request.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-    request.putHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-    if (params.getOkapiUrl().contains("https")) {
-      request.ssl(true);
-    }
-    request.send(res -> {
-      if (res.failed()) {
-        logError(res.cause(), params);
-        promise.complete(Optional.empty());
-      } else {
-        HttpResponse<Buffer> response = res.result();
-        if (response.statusCode() != HttpStatus.SC_OK) {
-          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, response.statusCode())), params);
-          promise.complete(Optional.empty());
-        } else {
-          try {
-            JsonObject instances = response.bodyAsJsonObject();
-            if (instances != null) {
-              promise.complete(Optional.of(instances));
-            } else {
-              logError(new IllegalStateException(format(ERROR_MESSAGE_EMPTY_BODY, endpoint)), params);
-              promise.complete(Optional.empty());
-            }
-          } catch (DecodeException ex) {
-            LOGGER.debug("Cannot process instances, invalid json body returned.", ex);
-            logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_BODY, endpoint, response.bodyAsString())), params);
-            promise.complete(Optional.empty());
-          }
-        }
-      }
-    });
-    return promise.future();
-  }
-
-  private void logError(Throwable throwable, OkapiConnectionParams params) {
-    LOGGER.error(throwable.getMessage(), throwable.getCause());
-    errorLogService.saveGeneralErrorWithMessageValues(ErrorCode.ERROR_GETTING_INSTANCES_BY_IDS.getCode(), Arrays.asList(throwable.getMessage()), StringUtils.EMPTY, params.getTenantId());
   }
 
   public Map<String, JsonObject> getNatureOfContentTerms(String jobExecutionId, OkapiConnectionParams params) {

--- a/src/main/java/org/folio/clients/SearchClient.java
+++ b/src/main/java/org/folio/clients/SearchClient.java
@@ -1,0 +1,99 @@
+package org.folio.clients;
+
+import static java.lang.String.format;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.util.ExternalPathResolver.SEARCH_IDS;
+import static org.folio.util.ExternalPathResolver.resourcesPathWithPrefix;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.service.logs.ErrorLogService;
+import org.folio.util.ErrorCode;
+import org.folio.util.OkapiConnectionParams;
+import org.folio.util.StringUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.MediaType;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Optional;
+
+@Component
+public class SearchClient {
+  private static final Logger LOGGER = LogManager.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String QUERY = "?query=";
+  private static final String ERROR_MESSAGE_INVALID_STATUS_CODE = "Exception while calling %s, message: Get invalid response with status: %s";
+  private static final String ERROR_MESSAGE_INVALID_BODY = "Exception while calling %s, message: Got invalid response body: %s";
+  private static final String ERROR_MESSAGE_EMPTY_BODY = "Exception while calling %s, message: empty body returned.";
+
+  private final WebClient webClient;
+  private final ErrorLogService errorLogService;
+
+  @Autowired
+  public SearchClient(WebClient webClient, ErrorLogService errorLogService) {
+    this.webClient = webClient;
+    this.errorLogService = errorLogService;
+  }
+
+  public Future<Optional<JsonObject>> getInstancesBulkUUIDsAsync(String query, OkapiConnectionParams params) {
+    Promise<Optional<JsonObject>> promise = Promise.promise();
+    if (StringUtils.isEmpty(query)) {
+      promise.complete(Optional.empty());
+      return promise.future();
+    }
+    String endpoint = format(resourcesPathWithPrefix(SEARCH_IDS), params.getOkapiUrl()) + QUERY + StringUtil.urlEncode(query);
+    HttpRequest<Buffer> request = webClient.getAbs(endpoint);
+    request.putHeader(OKAPI_HEADER_TOKEN, params.getToken());
+    request.putHeader(OKAPI_HEADER_TENANT, params.getTenantId());
+    request.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+    request.putHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+    if (params.getOkapiUrl().contains("https")) {
+      request.ssl(true);
+    }
+    request.send(res -> {
+      if (res.failed()) {
+        logError(res.cause(), params);
+        promise.complete(Optional.empty());
+      } else {
+        HttpResponse<Buffer> response = res.result();
+        if (response.statusCode() != HttpStatus.SC_OK) {
+          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, response.statusCode())), params);
+          promise.complete(Optional.empty());
+        } else {
+          try {
+            JsonObject instances = response.bodyAsJsonObject();
+            if (instances != null) {
+              promise.complete(Optional.of(instances));
+            } else {
+              logError(new IllegalStateException(format(ERROR_MESSAGE_EMPTY_BODY, endpoint)), params);
+              promise.complete(Optional.empty());
+            }
+          } catch (DecodeException ex) {
+            LOGGER.debug("Cannot process instances, invalid json body returned.", ex);
+            logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_BODY, endpoint, response.bodyAsString())), params);
+            promise.complete(Optional.empty());
+          }
+        }
+      }
+    });
+    return promise.future();
+  }
+
+  private void logError(Throwable throwable, OkapiConnectionParams params) {
+    LOGGER.error(throwable.getMessage(), throwable.getCause());
+    errorLogService.saveGeneralErrorWithMessageValues(ErrorCode.ERROR_GETTING_INSTANCES_BY_IDS.getCode(), Arrays.asList(throwable.getMessage()), StringUtils.EMPTY, params.getTenantId());
+  }
+}

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
-import org.folio.clients.InventoryClient;
+import org.folio.clients.SearchClient;
 import org.folio.clients.UsersClient;
 import org.folio.rest.exceptions.ServiceException;
 import org.folio.rest.jaxrs.model.FileDefinition;
@@ -43,7 +43,7 @@ public class FileUploadServiceImpl implements FileUploadService {
   @Autowired
   private FileStorage fileStorage;
   @Autowired
-  private InventoryClient inventoryClient;
+  private SearchClient searchClient;
   @Autowired
   private ErrorLogService errorLogService;
   @Autowired
@@ -81,7 +81,7 @@ public class FileUploadServiceImpl implements FileUploadService {
   @Override
   public Future<FileDefinition> saveUUIDsByCQL(FileDefinition fileDefinition, String query, OkapiConnectionParams params) {
     if (StringUtils.isNotBlank(query)) {
-      return inventoryClient.getInstancesBulkUUIDsAsync(query, params).compose(optionalInstancesUUIDs -> {
+      return searchClient.getInstancesBulkUUIDsAsync(query, params).compose(optionalInstancesUUIDs -> {
         List<String> ids = new ArrayList<>();
         if (optionalInstancesUUIDs.isPresent()) {
           JsonArray jsonIds = optionalInstancesUUIDs.get().getJsonArray("ids");
@@ -147,7 +147,7 @@ public class FileUploadServiceImpl implements FileUploadService {
 
   private Future<FileDefinition> uploadFileWithCQLQueryQuickExport(QuickExportRequest request, FileDefinition fileDefinition, JobExecution jobExecution, OkapiConnectionParams params) {
     Promise<FileDefinition> promise = Promise.promise();
-    inventoryClient.getInstancesBulkUUIDsAsync(request.getCriteria(), params).onComplete(instancesUUIDsResult -> {
+    searchClient.getInstancesBulkUUIDsAsync(request.getCriteria(), params).onComplete(instancesUUIDsResult -> {
       Optional<JsonObject> instancesUUIDs = instancesUUIDsResult.result();
       if (instancesUUIDs.isPresent()) {
         saveUUIDsFromJson(instancesUUIDs.get(), fileDefinition, jobExecution, request, params)

--- a/src/main/java/org/folio/util/ExternalPathResolver.java
+++ b/src/main/java/org/folio/util/ExternalPathResolver.java
@@ -34,6 +34,7 @@ public class ExternalPathResolver {
   public static final String ITEM = "item";
   public static final String CONFIGURATIONS = "configurations";
   public static final String RECORD_BULK_IDS = "bulkIds";
+  public static final String SEARCH_IDS = "searchIds";
 
 
   private static final Map<String, String> EXTERNAL_APIS;
@@ -67,6 +68,7 @@ public class ExternalPathResolver {
     apis.put(RECORD_BULK_IDS, "/record-bulk/ids");
     apis.put(USERS, "/users");
     apis.put(CONFIGURATIONS, "/configurations/entries");
+    apis.put(SEARCH_IDS, "/search/instances/ids");
 
     EXTERNAL_APIS = Collections.unmodifiableMap(apis);
     EXTERNAL_APIS_WITH_PREFIX = Collections.unmodifiableMap(apis.entrySet()

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -61,54 +61,7 @@ class InventoryClientTest extends RestVerticleTestBase {
     Assert.assertEquals(1, inventoryResponse.get().getJsonArray("instances").getList().size());
   }
 
-  @Test
-  void shouldRetrieveInstanceBulkUUIDS(VertxTestContext testContext) {
-    // given
-    String query = "cql query";
-    // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isPresent());
-      Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
 
-  @Test
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext) {
-    // given
-    String query = "inventory 500";
-    // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isEmpty());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
-
-  @Test
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndEmptyJsonBodyReturned(VertxTestContext testContext) {
-    // given
-    String query = "empty json response";
-    // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isEmpty());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
-
-  @Test
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidJsonBodyReturned(VertxTestContext testContext) {
-    // given
-    String query = "invalid json returned";
-    // when
-    inventoryClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isEmpty());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
 
   @Test
   void shouldRetrieveNatureOfContentTerms() {

--- a/src/test/java/org/folio/rest/impl/InventoryClientTest.java
+++ b/src/test/java/org/folio/rest/impl/InventoryClientTest.java
@@ -4,7 +4,6 @@ import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.junit5.VertxExtension;
-import io.vertx.junit5.VertxTestContext;
 
 import java.util.UUID;
 

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -410,6 +410,8 @@ public class MockServer {
         ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end();
       } else if (ctx.request().getParam("query").contains("invalid json returned")) {
         ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end("{qwe");
+      } else if (ctx.request().getParam("query").contains("bad request")) {
+        ctx.response().setStatusCode(400).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end();
       } else {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, SEARCH_IDS, ctx);
       }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -137,7 +137,7 @@ public class MockServer {
     router.get(resourcesPath(HOLDING)).handler(ctx -> handleGetHoldingRecord(ctx));
     router.get(resourcesPath(ITEM)).handler(ctx -> handleGetItemRecord(ctx));
     router.get(resourcesPath(CONFIGURATIONS)).handler(ctx -> handleGetConfigurations(ctx));
-    router.get(resourcesPath(RECORD_BULK_IDS)).handler(ctx -> handleGetInstanceBulkIds(ctx));
+    router.get(resourcesPath(SEARCH_IDS)).handler(ctx -> handleGetInstanceBulkIds(ctx));
     return router;
   }
 
@@ -401,9 +401,9 @@ public class MockServer {
     try {
       JsonObject bulkIds;
       if (ctx.request().getParam("query").contains("(languages=\"eng\")")) {
-        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
+        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH, SEARCH_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("(languages=\"uk\")")) {
-        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_WITH_RANDOM, RECORD_BULK_IDS, ctx);
+        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_WITH_RANDOM, SEARCH_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("inventory 500")) {
         mockResponseWith500Status(ctx);
       } else if (ctx.request().getParam("query").contains("empty json response")) {
@@ -411,7 +411,7 @@ public class MockServer {
       } else if (ctx.request().getParam("query").contains("invalid json returned")) {
         ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end("{qwe");
       } else {
-        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, RECORD_BULK_IDS, ctx);
+        getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_MOCK_DATA_PATH, SEARCH_IDS, ctx);
       }
     } catch (IOException e) {
       mockResponseWith500Status(ctx);

--- a/src/test/java/org/folio/rest/impl/SearchClientTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchClientTest.java
@@ -3,7 +3,6 @@ package org.folio.rest.impl;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 import io.vertx.core.Context;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.commons.collections4.map.HashedMap;
@@ -16,16 +15,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Map;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(VertxExtension.class)
-@RunWith(VertxUnitRunner.class)
 public class SearchClientTest extends RestVerticleTestBase {
   private static OkapiConnectionParams okapiConnectionParams;
 
@@ -56,10 +51,34 @@ public class SearchClientTest extends RestVerticleTestBase {
     }).onFailure(testContext::failNow);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"inventory 500", "empty json response", "invalid json returned"})
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext, String query) {
-    // given query parameter
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext) {
+    // given
+    String query = "inventory 500";
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndEmptyJsonBodyReturned(VertxTestContext testContext) {
+    // given
+    String query = "empty json response";
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidJsonBodyReturned(VertxTestContext testContext) {
+    // given
+    String query = "invalid json returned";
     // when
     searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then

--- a/src/test/java/org/folio/rest/impl/SearchClientTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchClientTest.java
@@ -52,6 +52,18 @@ public class SearchClientTest extends RestVerticleTestBase {
   }
 
   @Test
+  void shouldReturnEmptyOptional_whenQueryIsEmpty(VertxTestContext testContext) {
+    // given
+    String query = "";
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
   void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext) {
     // given
     String query = "inventory 500";
@@ -79,6 +91,18 @@ public class SearchClientTest extends RestVerticleTestBase {
   void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidJsonBodyReturned(VertxTestContext testContext) {
     // given
     String query = "invalid json returned";
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @Test
+  void shouldReturnEmptyOptional_whenResponseStatusFromSearchIsNotOk(VertxTestContext testContext) {
+    // given
+    String query = "bad request";
     // when
     searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
       //then

--- a/src/test/java/org/folio/rest/impl/SearchClientTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchClientTest.java
@@ -1,0 +1,70 @@
+package org.folio.rest.impl;
+
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+
+import io.vertx.core.Context;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.commons.collections4.map.HashedMap;
+import org.folio.clients.SearchClient;
+import org.folio.config.ApplicationConfig;
+import org.folio.spring.SpringContextUtil;
+import org.folio.util.OkapiConnectionParams;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(VertxExtension.class)
+@RunWith(VertxUnitRunner.class)
+public class SearchClientTest extends RestVerticleTestBase {
+  private static OkapiConnectionParams okapiConnectionParams;
+
+  @Autowired
+  private SearchClient searchClient;
+
+  @BeforeAll
+  void beforeClass() {
+    Map<String, String> headers = new HashedMap<>();
+    headers.put(OKAPI_HEADER_TENANT, TENANT_ID);
+    headers.put(OKAPI_HEADER_URL, MOCK_OKAPI_URL);
+    okapiConnectionParams = new OkapiConnectionParams(headers);
+    Context context = vertx.getOrCreateContext();
+    SpringContextUtil.init(vertx, context, ApplicationConfig.class);
+    SpringContextUtil.autowireDependencies(this, context);
+  }
+
+  @Test
+  void shouldRetrieveInstanceBulkUUIDS(VertxTestContext testContext) {
+    // given
+    String query = "cql query";
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isPresent());
+      Assert.assertEquals(2, inventoryResponse.get().getJsonArray("ids").getList().size());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"inventory 500", "empty json response", "invalid json returned"})
+  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidResponseReturned(VertxTestContext testContext, String query) {
+    // given query parameter
+    // when
+    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
+      //then
+      Assert.assertTrue(inventoryResponse.isEmpty());
+      testContext.completeNow();
+    }).onFailure(testContext::failNow);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/impl/StorageTestSuite.java
@@ -177,4 +177,9 @@ public class StorageTestSuite {
   class TenantReferenceAPITestNested extends TenantReferenceAPITest {
 
   }
+
+  @Nested
+  class SearchClientTestNested extends SearchClientTest {
+
+  }
 }

--- a/src/test/java/org/folio/service/file/upload/FileUploadServiceUnitTest.java
+++ b/src/test/java/org/folio/service/file/upload/FileUploadServiceUnitTest.java
@@ -7,6 +7,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.commons.collections4.map.HashedMap;
 import org.folio.clients.InventoryClient;
+import org.folio.clients.SearchClient;
 import org.folio.clients.UsersClient;
 import org.folio.rest.impl.RestVerticleTestBase;
 import org.folio.rest.jaxrs.model.FileDefinition;
@@ -78,6 +79,8 @@ class FileUploadServiceUnitTest {
   UsersClient usersClient;
   @Mock
   InventoryClient inventoryClient;
+  @Mock
+  SearchClient searchClient;
   private OkapiConnectionParams params;
   private FileDefinition fileDefinition;
   private JsonObject user;
@@ -149,7 +152,7 @@ class FileUploadServiceUnitTest {
     when(jobExecutionService.getById(JOB_EXECUTION_ID, TENANT_ID)).thenReturn(succeededFuture());
     when(fileDefinitionService.update(any(FileDefinition.class), anyString())).thenReturn(succeededFuture(inProgressDef))
       .thenReturn(succeededFuture(completedDef));
-    when(inventoryClient.getInstancesBulkUUIDsAsync(eq("test"), any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(Optional.empty()));
+    when(searchClient.getInstancesBulkUUIDsAsync(eq("test"), any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(Optional.empty()));
 
     // when
     Future<FileDefinition> fileDefinitionFuture = fileUploadService.uploadFileDependsOnTypeForQuickExport(quickExportRequest, fileDefinition, params);
@@ -183,7 +186,7 @@ class FileUploadServiceUnitTest {
     when(jobExecutionService.update(any(JobExecution.class), eq(TENANT_ID))).thenReturn(succeededFuture(jobExecution));
     when(fileDefinitionService.update(any(FileDefinition.class), anyString())).thenReturn(succeededFuture(inProgressDef))
       .thenReturn(succeededFuture(completedDef));
-    when(inventoryClient.getInstancesBulkUUIDsAsync(anyString(), eq(params))).thenReturn(Future.succeededFuture(of(new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH)))));
+    when(searchClient.getInstancesBulkUUIDsAsync(anyString(), eq(params))).thenReturn(Future.succeededFuture(of(new JsonObject(RestVerticleTestBase.getMockData(INSTANCE_BULK_IDS_ALL_VALID_MOCK_DATA_PATH)))));
     when(fileStorage.saveFileDataAsyncCQL(anyList(), any(FileDefinition.class))).thenReturn(succeededFuture(completedDef));
 
     // when


### PR DESCRIPTION
[MDEXP-473](https://issues.folio.org/browse/MDEXP-473) - CQL export fails when effective location is included in the cql statement

## Purpose
The export fails when triggered by CQL and the effective location is a part of the statement. If works fine if the location is not present

## Approach
* Introduced mod-search client to leverage `/search/instances/ids` API instead of mod-inventory storage API to get instance IDs
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
