### PR TITLE
MDEXP-475 - Bugfest - the export cannot be triggered by the long CQL statement

### DIFF
--- a/src/main/java/org/folio/clients/SearchClient.java
+++ b/src/main/java/org/folio/clients/SearchClient.java
@@ -96,10 +96,9 @@ public class SearchClient {
       if (res.failed()) {
         logError(res.cause(), params);
         promise.complete(Optional.empty());
-      }
-      if (res.result().statusCode() != HttpStatus.SC_OK) {
-          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, res.result().statusCode())), params);
-          promise.complete(Optional.empty());
+      } else if (res.result().statusCode() != HttpStatus.SC_OK) {
+        logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, res.result().statusCode())), params);
+        promise.complete(Optional.empty());
       }
     });
     return promise.future();

--- a/src/main/java/org/folio/clients/SearchClient.java
+++ b/src/main/java/org/folio/clients/SearchClient.java
@@ -3,19 +3,21 @@ package org.folio.clients;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 
+import static org.apache.logging.log4j.util.Strings.EMPTY;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
 import static org.folio.util.ExternalPathResolver.SEARCH_IDS;
 import static org.folio.util.ExternalPathResolver.resourcesPathWithPrefix;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.parsetools.JsonParser;
 import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.codec.BodyCodec;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -67,42 +69,44 @@ public class SearchClient {
     if (params.getOkapiUrl().contains("https")) {
       request.ssl(true);
     }
-    request.send(res -> {
+    var parser = JsonParser.newParser().objectValueMode();
+    parser
+      .handler(event -> {
+        var instances = event.objectValue();
+        if (nonNull(instances)) {
+          if (instances.getJsonArray(IDS_LIST).isEmpty()) {
+            logError(new IllegalStateException(format(ERROR_MESSAGE_NO_RECORDS, endpoint)), params);
+            promise.complete(Optional.empty());
+          } else {
+            promise.complete(Optional.of(instances));
+          }
+        } else {
+          logError(new IllegalStateException(format(ERROR_MESSAGE_EMPTY_BODY, endpoint)), params);
+          promise.complete(Optional.empty());
+        }})
+      .exceptionHandler(throwable -> {
+        if (throwable instanceof JsonParseException) {
+          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_BODY, endpoint, throwable.getMessage())), params);
+        } else {
+          logError(throwable.getCause(), params);
+        }
+        promise.tryComplete(Optional.empty());
+      });
+    request.as(BodyCodec.jsonStream(parser)).send(res -> {
       if (res.failed()) {
         logError(res.cause(), params);
         promise.complete(Optional.empty());
-      } else {
-        HttpResponse<Buffer> response = res.result();
-        if (response.statusCode() != HttpStatus.SC_OK) {
-          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, response.statusCode())), params);
+      }
+      if (res.result().statusCode() != HttpStatus.SC_OK) {
+          logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_STATUS_CODE, endpoint, res.result().statusCode())), params);
           promise.complete(Optional.empty());
-        } else {
-          try {
-            JsonObject instances = response.bodyAsJsonObject();
-            if (nonNull(instances)) {
-              if (instances.getJsonArray(IDS_LIST).isEmpty()) {
-                logError(new IllegalStateException(format(ERROR_MESSAGE_NO_RECORDS, endpoint)), params);
-                promise.complete(Optional.empty());
-              } else {
-                promise.complete(Optional.of(instances));
-              }
-            } else {
-              logError(new IllegalStateException(format(ERROR_MESSAGE_EMPTY_BODY, endpoint)), params);
-              promise.complete(Optional.empty());
-            }
-          } catch (DecodeException ex) {
-            LOGGER.debug("Cannot process instances, invalid json body returned.", ex);
-            logError(new IllegalStateException(format(ERROR_MESSAGE_INVALID_BODY, endpoint, response.bodyAsString())), params);
-            promise.complete(Optional.empty());
-          }
-        }
       }
     });
     return promise.future();
   }
 
   private void logError(Throwable throwable, OkapiConnectionParams params) {
-    LOGGER.error(throwable.getMessage(), throwable.getCause());
+    LOGGER.error(throwable.getMessage(), nonNull(throwable.getCause()) ? throwable.getCause() : EMPTY);
     errorLogService.saveGeneralErrorWithMessageValues(ErrorCode.ERROR_GETTING_INSTANCES_BY_IDS.getCode(), Arrays.asList(throwable.getMessage()), StringUtils.EMPTY, params.getTenantId());
   }
 }

--- a/src/test/java/org/folio/rest/impl/MockServer.java
+++ b/src/test/java/org/folio/rest/impl/MockServer.java
@@ -409,8 +409,6 @@ public class MockServer {
         getMockResponseFromPathWith200Status(INSTANCE_BULK_IDS_NO_RECORDS, SEARCH_IDS, ctx);
       } else if (ctx.request().getParam("query").contains("inventory 500")) {
         mockResponseWith500Status(ctx);
-      } else if (ctx.request().getParam("query").contains("empty json response")) {
-        ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end();
       } else if (ctx.request().getParam("query").contains("invalid json returned")) {
         ctx.response().setStatusCode(200).putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON).end("{qwe");
       } else if (ctx.request().getParam("query").contains("bad request")) {

--- a/src/test/java/org/folio/rest/impl/SearchClientTest.java
+++ b/src/test/java/org/folio/rest/impl/SearchClientTest.java
@@ -76,18 +76,6 @@ public class SearchClientTest extends RestVerticleTestBase {
   }
 
   @Test
-  void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndEmptyJsonBodyReturned(VertxTestContext testContext) {
-    // given
-    String query = "empty json response";
-    // when
-    searchClient.getInstancesBulkUUIDsAsync(query, okapiConnectionParams).onSuccess(inventoryResponse -> {
-      //then
-      Assert.assertTrue(inventoryResponse.isEmpty());
-      testContext.completeNow();
-    }).onFailure(testContext::failNow);
-  }
-
-  @Test
   void shouldReturnEmptyOptional_whenRequestInstanceBulkUUIDsAndInvalidJsonBodyReturned(VertxTestContext testContext) {
     // given
     String query = "invalid json returned";


### PR DESCRIPTION
[MDEXP-475](https://issues.folio.org/browse/MDEXP-475) - Bugfest - the export cannot be triggered by the long CQL statement

## Purpose
The file with the long CQL statement never triggers the export

## Approach
* Improved mod-data-export to support json streams
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
