### PR TITLE
MDEXP-475 - Bugfest - the export cannot be triggered by the long CQL statement

### DIFF
--- a/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplFileDefinitionImpl.java
@@ -12,8 +12,6 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.shareddata.LocalMap;
-import io.vertx.core.shareddata.SharedData;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.folio.HttpStatus;
@@ -33,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitions {
@@ -40,7 +39,6 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
   public static final String CSV_FORMAT_EXTENSION = "csv";
   public static final String CQL_FORMAT_EXTENSION = "cql";
 
-  private static final String QUERIES_MAP = "queries";
   private static final String QUERY_KEY = "query";
 
   @Autowired
@@ -49,7 +47,7 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
   @Autowired
   private FileUploadService fileUploadService;
 
-  private SharedData sharedData;
+  private final Map<String, String> map = new HashMap<>();
 
   /*
       Reference to the Future to keep uploading state in track while uploading happens.
@@ -62,7 +60,6 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
   public DataExportImplFileDefinitionImpl(Vertx vertx, String tenantId) { //NOSONAR
     SpringContextUtil.autowireDependencies(this, Vertx.currentContext());
     this.tenantId = TenantTool.calculateTenantId(tenantId);
-    this.sharedData = vertx.sharedData();
   }
 
   @Override
@@ -121,7 +118,6 @@ public class DataExportImplFileDefinitionImpl implements DataExportFileDefinitio
   }
 
   private Future<FileDefinition> saveFileDependsOnFileExtension(FileDefinition fileDefinition, byte[] data, OkapiConnectionParams params) {
-    final LocalMap<String, String> map = sharedData.getLocalMap(QUERIES_MAP);
     if (CQL.equals(fileDefinition.getUploadFormat())) {
       var queryChunk = new String(data);
       if (queryChunk.isEmpty()) {


### PR DESCRIPTION
[MDEXP-475](https://issues.folio.org/browse/MDEXP-475) - Bugfest - the export cannot be triggered by the long CQL statement

## Purpose
The file with the long CQL statement never triggers the export

## Approach
* Fixed logic

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
