### PR TITLE
MDEXP-488 - Release 4.1.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ## 4.2.0 - Unreleased
 
+## 12/17/2021 v4.1.2 Released
+This release includes fix for log4j vulnerability
+
+[Full Changelog](https://github.com/folio-org/mod-data-export/compare/v4.1.1...v4.1.2)
+
+### Bug fixes
+* [MDEXP-484](https://issues.folio.org/browse/MDEXP-484) Kiwi R3 2021 - Log4j vulnerability verification and correction
+
 ## 23/09/2021 v4.1.1 Released
 This release includes handling of errors caused by MARC records that exceed a size limit, as well as any other errors like
 no-escaped control characters in quoted literals, or data after closing quotes.

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.16.0</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -88,7 +95,6 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.marc4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>4.1.2</version>
+  <version>4.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -526,7 +526,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>v4.1.2</tag>
+    <tag>v4.1.1</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-data-export</artifactId>
-  <version>4.2.0-SNAPSHOT</version>
+  <version>4.1.2</version>
   <packaging>jar</packaging>
 
   <licenses>
@@ -526,7 +526,7 @@
     <url>https://github.com/folio-org/mod-data-export</url>
     <connection>scm:git:git://github.com/folio-org/mod-data-export</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-data-export.git</developerConnection>
-    <tag>v4.1.1</tag>
+    <tag>v4.1.2</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
[MDEXP-488](https://issues.folio.org/browse/MDEXP-488) - MDEXP (mod-data-export) Juniper Hotfix release