### PR TITLE
MDEXP-124 - Generate MARC bib record  - 500$a/notes

### DIFF
--- a/src/main/resources/rules/rulesDefault.json
+++ b/src/main/resources/rules/rulesDefault.json
@@ -1396,6 +1396,35 @@
     ]
   },
   {
+    "id": "instance.notes.note",
+    "field": "500",
+    "description": "Instance note",
+    "dataSources": [
+      {
+        "from": "$.instance.notes[?(@.staffOnly == false)].note",
+        "subfield": "a"
+      },
+      {
+        "indicator": "1",
+        "translation": {
+          "function": "set_value",
+          "parameters": {
+            "value": " "
+          }
+        }
+      },
+      {
+        "indicator": "2",
+        "translation": {
+          "function": "set_value",
+          "parameters": {
+            "value": " "
+          }
+        }
+      }
+    ]
+  },
+  {
     "id": "instance.subjects",
     "field": "653",
     "description": "Physical Descriptions",

--- a/src/test/resources/mapping/expected_marc.json
+++ b/src/test/resources/mapping/expected_marc.json
@@ -347,6 +347,17 @@
       }
     },
     {
+      "500": {
+        "subfields": [
+          {
+            "a": "Previous edition: 2011"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
       "653": {
         "subfields": [
           {

--- a/src/test/resources/mapping/given_inventory_instance.json
+++ b/src/test/resources/mapping/given_inventory_instance.json
@@ -285,6 +285,18 @@
         "identifierTypeId": "1795ea23-6856-48a5-a772-f356e16a8a6c"
       }
     ],
+    "notes": [
+      {
+        "note": "Previous edition: 2011",
+        "staffOnly": false,
+        "instanceNoteTypeId": "5b15c7bf-3f86-4e1a-9b05-6895467147c9"
+      },
+      {
+        "note": "Includes bibliographical references and index",
+        "staffOnly": true,
+        "instanceNoteTypeId": "1e4c2471-4604-4249-8f22-efa1715f9ea6"
+      }
+    ],
     "contributors": [
       {
         "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",


### PR DESCRIPTION
[MDEXP-124](https://issues.folio.org/browse/MDEXP-124) - Generate MARC bib record  - 500$a/notes

## Purpose
All note types associated with the inventory instance that are not marked as "staffOnly" should be mapped to 500 $a MARC field in accordance with the recommended mapping.

## Approach
* Updated transformation rules
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
