### PR TITLE
MDEXP-499: Existing holdings UUIDs are reported as invalid while exporting holdings record

### DIFF
--- a/src/main/java/org/folio/clients/InventoryClient.java
+++ b/src/main/java/org/folio/clients/InventoryClient.java
@@ -49,7 +49,6 @@ public class InventoryClient {
   private static final String LIMIT_PARAMETER = "?limit=";
   private static final String QUERY_PATTERN_INVENTORY = "id==%s";
   private static final String QUERY_LIMIT_PATTERN = "?query=(%s)&limit=";
-  private static final String QUERY_PATTERN = "?query=(%s)";
   private static final String QUERY_PATTERN_HOLDING = "instanceId==%s";
   private static final String QUERY_PATTERN_ITEM = "holdingsRecordId==%s";
   private static final int REFERENCE_DATA_LIMIT = 1000;
@@ -69,9 +68,9 @@ public class InventoryClient {
     }
   }
 
-  public Optional<JsonObject> getHoldingsByIds(List<String> ids, String jobExecutionId, OkapiConnectionParams params) {
+  public Optional<JsonObject> getHoldingsByIds(List<String> ids, String jobExecutionId, OkapiConnectionParams params, int partitionSize) {
     try {
-      return Optional.of(ClientUtil.getByIds(ids, params, resourcesPathWithPrefix(HOLDING) + QUERY_PATTERN,
+      return Optional.of(ClientUtil.getByIds(ids, params, resourcesPathWithPrefix(HOLDING) + QUERY_LIMIT_PATTERN + partitionSize,
         QUERY_PATTERN_INVENTORY));
     } catch (HttpClientException exception) {
       LOGGER.error(exception.getMessage(), exception.getCause());

--- a/src/main/java/org/folio/service/loader/RecordLoaderService.java
+++ b/src/main/java/org/folio/service/loader/RecordLoaderService.java
@@ -50,8 +50,9 @@ public interface RecordLoaderService {
    * @param holdingIds     holding ids
    * @param jobExecutionId job execution id
    * @param params         okapi headers and connection parameters
+   * @param partitionSize  partition size
    */
-  LoadResult getHoldingsById(List<String> holdingIds, String jobExecutionId, OkapiConnectionParams params);
+  LoadResult getHoldingsById(List<String> holdingIds, String jobExecutionId, OkapiConnectionParams params, int partitionSize);
 
   /**
    * Retrieve all Items for the list of holding UUIDs

--- a/src/main/java/org/folio/service/loader/RecordLoaderServiceImpl.java
+++ b/src/main/java/org/folio/service/loader/RecordLoaderServiceImpl.java
@@ -64,8 +64,8 @@ public class RecordLoaderServiceImpl implements RecordLoaderService {
   }
 
   @Override
-  public LoadResult getHoldingsById(List<String> holdingIds, String jobExecutionId, OkapiConnectionParams params) {
-    Optional<JsonObject> optionalRecords = inventoryClient.getHoldingsByIds(holdingIds, jobExecutionId, params);
+  public LoadResult getHoldingsById(List<String> holdingIds, String jobExecutionId, OkapiConnectionParams params, int partitionSize) {
+    Optional<JsonObject> optionalRecords = inventoryClient.getHoldingsByIds(holdingIds, jobExecutionId, params, partitionSize);
     LoadResult holdingsLoadResult = new LoadResult();
     holdingsLoadResult.setEntityType(AbstractExportStrategy.EntityType.HOLDING);
     if (optionalRecords.isPresent()) {

--- a/src/main/java/org/folio/service/manager/export/strategy/HoldingExportStrategyImpl.java
+++ b/src/main/java/org/folio/service/manager/export/strategy/HoldingExportStrategyImpl.java
@@ -83,7 +83,7 @@ public class HoldingExportStrategyImpl extends AbstractExportStrategy {
   private LoadResult loadHoldingsInPartitions(List<String> holdingIdentifiers, String jobExecutionId, OkapiConnectionParams params) {
     LoadResult loadResult = new LoadResult();
     Lists.partition(holdingIdentifiers, ExportManagerImpl.INVENTORY_LOAD_PARTITION_SIZE).forEach(partition -> {
-        LoadResult partitionLoadResult = getRecordLoaderService().getHoldingsById(partition, jobExecutionId, params);
+        LoadResult partitionLoadResult = getRecordLoaderService().getHoldingsById(partition, jobExecutionId, params, ExportManagerImpl.INVENTORY_LOAD_PARTITION_SIZE);
         loadResult.getEntities().addAll(partitionLoadResult.getEntities());
         loadResult.getNotFoundEntitiesUUIDs().addAll(partitionLoadResult.getNotFoundEntitiesUUIDs());
       }

--- a/src/main/java/org/folio/service/mapping/converter/RecordConverter.java
+++ b/src/main/java/org/folio/service/mapping/converter/RecordConverter.java
@@ -20,9 +20,12 @@ import io.vertx.core.json.JsonObject;
 import static org.folio.service.manager.export.ExportManagerImpl.INVENTORY_LOAD_PARTITION_SIZE;
 
 public class RecordConverter {
+
   private static final Logger LOGGER = LogManager.getLogger(MethodHandles.lookup()
     .lookupClass());
+
   private static final int SINGLE_HOLDING_POSITION = 0;
+  private static final int PARTITION_SIZE = 1;
 
   @Autowired
   private RecordLoaderService recordLoaderService;
@@ -44,7 +47,7 @@ public class RecordConverter {
       if (recordType.equals(RecordType.INSTANCE)) {
         holdings = recordLoaderService.getHoldingsForInstance(recordId, jobExecutionId, params);
       } else {
-        LoadResult holding = recordLoaderService.getHoldingsById(Collections.singletonList(recordId), jobExecutionId, params);
+        LoadResult holding = recordLoaderService.getHoldingsById(Collections.singletonList(recordId), jobExecutionId, params, PARTITION_SIZE);
         holdings = holding.getEntities();
       }
       if (mappingProfile.getRecordTypes().contains(RecordType.ITEM) && CollectionUtils.isNotEmpty(holdings)) {

--- a/src/test/java/org/folio/service/manager/export/HoldingExportStrategyUnitTest.java
+++ b/src/test/java/org/folio/service/manager/export/HoldingExportStrategyUnitTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.vertx.core.Promise;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -68,7 +69,7 @@ public class HoldingExportStrategyUnitTest {
     Mockito.when(marcLoadResult.getIdsWithoutSrs()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
     Mockito.when(loadResult.getNotFoundEntitiesUUIDs()).thenReturn(Collections.singletonList(UUID.randomUUID().toString()));
     Mockito.when(recordLoaderService.loadMarcRecordsBlocking(anyList(), eq(AbstractExportStrategy.EntityType.HOLDING), anyString(), any(OkapiConnectionParams.class))).thenReturn(marcLoadResult);
-    Mockito.when(recordLoaderService.getHoldingsById(anyList(), anyString(), any(OkapiConnectionParams.class))).thenReturn(loadResult);
+    Mockito.when(recordLoaderService.getHoldingsById(anyList(), anyString(), any(OkapiConnectionParams.class), anyInt())).thenReturn(loadResult);
     Mockito.when(srsRecordService.transformSrsRecords(any(MappingProfile.class), anyList(), anyString(), any(OkapiConnectionParams.class), eq(AbstractExportStrategy.EntityType.HOLDING))).thenReturn(
       Pair.of(Collections.emptyList(), 0));
     Mockito.when(inventoryRecordService.transformHoldingRecords(anyList(), anyString(), any(MappingProfile.class), any(OkapiConnectionParams.class))).thenReturn(
@@ -85,7 +86,7 @@ public class HoldingExportStrategyUnitTest {
     holdingExportManager.export(exportPayload, Promise.promise());
     // then
     Mockito.verify(recordLoaderService, Mockito.times(20)).loadMarcRecordsBlocking(anyList(), eq(AbstractExportStrategy.EntityType.HOLDING), anyString(), any(OkapiConnectionParams.class));
-    Mockito.verify(recordLoaderService, Mockito.times(1)).getHoldingsById(anyList(), anyString(), any(OkapiConnectionParams.class));
+    Mockito.verify(recordLoaderService, Mockito.times(1)).getHoldingsById(anyList(), anyString(), any(OkapiConnectionParams.class), anyInt());
     Mockito.verify(exportService, Mockito.times(1)).exportSrsRecord(any(Pair.class), any(ExportPayload.class));
     Mockito.verify(inventoryRecordService, Mockito.times(1)).transformHoldingRecords(anyList(), anyString(), any(MappingProfile.class), any(OkapiConnectionParams.class));
     Mockito.verify(exportService, Mockito.times(1)).postExport(any(FileDefinition.class), anyString());


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-499

### PURPOSE

Add limit parameter to holdings request. Previously the limit param was omitted which caused only 10 holdings to be returned in a response.