### PR TITLE
MDEXP-504: Exported holdings MARC records are combined with the records generated on the fly

### DIFF
--- a/src/main/java/org/folio/service/mapping/converter/SrsRecordConverterService.java
+++ b/src/main/java/org/folio/service/mapping/converter/SrsRecordConverterService.java
@@ -45,7 +45,7 @@ public class SrsRecordConverterService extends RecordConverter {
 
   public Pair<List<String>, Integer> transformSrsRecords(MappingProfile mappingProfile, List<JsonObject> srsRecords, String jobExecutionId,
                                                          OkapiConnectionParams connectionParams, AbstractExportStrategy.EntityType entityType) {
-    if (entityType.equals(AbstractExportStrategy.EntityType.INSTANCE) && isTransformationRequired(mappingProfile)) {
+    if (entityType == AbstractExportStrategy.EntityType.INSTANCE && isTransformationRequired(mappingProfile)) {
       return transformSrsRecord(mappingProfile, srsRecords, jobExecutionId, connectionParams, entityType);
     } else {
       return MutablePair.of(getRecordContent(srsRecords), 0);


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-504

### PURPOSE
Do not enrich existing srs records with inventory data when export holding records with source MARC 


### APPROACH 

Just return the plain MARC record as it is when transfromSrsRecords and EntityType equals HOLDING.

### Note

The current case will be covered by an additional integration test in the scope of https://issues.folio.org/browse/FAT-1479