### PR TITLE
MDEXP-511 FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,12 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-data-export
 
-Copyright (C) 2018-2020 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/samples/logs/errorLog.sample
+++ b/ramls/samples/logs/errorLog.sample
@@ -4,7 +4,7 @@
    "createdDate":"2019-07-22T11:22:07Z",
    "logLevel":"ERROR",
    "errorMessageCode":"error.code",
-   "errorMessageValues": [{"value"}],
+   "errorMessageValues": [{"value": "foo"}],
    "affectedRecord": {
        "id": "57c79d87-6510-4354-b212-96832fbf3fa1",
        "hrid": "200",

--- a/ramls/samples/logs/errorLogCollection.sample
+++ b/ramls/samples/logs/errorLogCollection.sample
@@ -20,7 +20,7 @@
                 "updatedByUserId": "dee12548-9cee-45fa-bbae-675c1cc0ce3b",
                 "updatedByUsername": ""
             }
-        },
-        "totalRecords": "1"
-    ]
+        }
+    ],
+    "totalRecords": "1"
 }

--- a/ramls/samples/logs/recordLog.sample
+++ b/ramls/samples/logs/recordLog.sample
@@ -3,7 +3,7 @@
     "hrid": "200",
     "title": "Holdings record",
     "recordType": "HOLDINGS",
-    "inventoryRecordLink": "https://folio-testing.dev.folio.org/inventory/view/57c79d87-6510-4354-b212-96832fbf3fa1"
+    "inventoryRecordLink": "https://folio-testing.dev.folio.org/inventory/view/57c79d87-6510-4354-b212-96832fbf3fa1",
     "affectedRecords": [{
         "id": "e50c1f7f-1174-476c-88b7-a2e2fa8e657d",
         "hrid": "201",


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-data-export section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config
