### PR TITLE
MDEXP-542 - Migration script fails if upgrading from version 4.2.4 to version 4.4.2

### DIFF
--- a/src/main/resources/templates/db_scripts/migration_scripts/add_default_profiles.sql
+++ b/src/main/resources/templates/db_scripts/migration_scripts/add_default_profiles.sql
@@ -21,7 +21,8 @@ INSERT INTO ${myuniversity}_${mymodule}.mapping_profiles(
     "updatedByUserId":"00000000-0000-0000-0000-000000000000",
     "updatedByUsername":"system_process"
   }
-}', NOW(), '00000000-0000-0000-0000-000000000000');
+}', NOW(), '00000000-0000-0000-0000-000000000000')
+ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.job_profiles(
 	id, jsonb, creation_date, created_by, mappingprofileid)
@@ -44,4 +45,5 @@ INSERT INTO ${myuniversity}_${mymodule}.job_profiles(
     "updatedByUserId":"00000000-0000-0000-0000-000000000000",
     "updatedByUsername":"system_process"
   }
-}', NOW(), '00000000-0000-0000-0000-000000000000', '1ef7d0ac-f0a8-42b5-bbbb-c7e249009c13');
+}', NOW(), '00000000-0000-0000-0000-000000000000', '1ef7d0ac-f0a8-42b5-bbbb-c7e249009c13')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
[MDEXP-542](https://issues.folio.org/browse/MDEXP-542) - Migration script fails if upgrading from version 4.2.4 to version 4.4.2

## Purpose
"Key (id) already exists" exception occurs upon migration script execution

## Approach
* fixed migration script

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
