### PR TITLE
MDEXP-551: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,15 +12,15 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.7 8.0"
+      "version": "7.7 8.0 9.0"
     },
     {
       "id": "holdings-storage",
-      "version": "4.5 5.0"
+      "version": "4.5 5.0 6.0"
     },
     {
       "id": "item-storage",
-      "version": "8.9 9.0"
+      "version": "8.9 9.0 10.0"
     },
     {
       "id": "nature-of-content-terms",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-data-export is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-data-export.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json