### PR TITLE
MDEXP-564: Upgrade dependencies fixing vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,11 @@
     <raml-module-builder.version>35.0.1</raml-module-builder.version>
     <vertx.version>4.3.4</vertx.version>
     <folio-di-support.version>1.6.0</folio-di-support.version>
-    <junit.version>5.4.2</junit.version>
-    <rest-assured.version>3.3.0</rest-assured.version>
-    <marc4j.version>2.9.1</marc4j.version>
+    <junit.version>5.9.1</junit.version>
+    <rest-assured.version>5.2.0</rest-assured.version>
+    <marc4j.version>2.9.2</marc4j.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <postgres-testing.version>33.0.0</postgres-testing.version>
-    <minio.version>8.3.0</minio.version>
+    <minio.version>8.4.5</minio.version>
     <generate-marc-utils-version>1.5.0-SNAPSHOT</generate-marc-utils-version>
 
     <sonar.exclusions>
@@ -51,9 +50,16 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.19.0</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -76,23 +82,19 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>${vertx.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
 
     <!-- other dependencies -->
@@ -113,22 +115,22 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.163</version>
+      <version>1.12.321</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.4.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.5.5</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
-      <version>3.22.1</version>
+      <version>3.24.4</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -151,25 +153,23 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>2.23.4</version>
+      <version>4.8.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.11.1</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-junit5</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -193,7 +193,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>postgres-testing</artifactId>
-      <version>${postgres-testing.version}</version>
+      <version>${raml-module-builder.version}</version>
     </dependency>
     <dependency>
       <groupId>io.minio</groupId>


### PR DESCRIPTION
For Nolana upgrade all pom.xml dependencies to the latest supported version.

Upgrade minio from 8.3.0 to 8.4.5.

The minio upgrade indirectly upgrades com.squareup.okhttp3:okhttp from 4.8.1 to 4.10.0 fixing an Information Exposure vulnerability: https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044

The minio upgrade indirectly upgrades kotlin-stdlib from 1.3.72 to 1.6.20 fixing Improper Locking https://nvd.nist.gov/vuln/detail/CVE-2022-24329 and Information Exposure https://nvd.nist.gov/vuln/detail/CVE-2020-29582

Upgrade log4j from 2.16.0 to 2.19.0 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2021-45105 and Arbitrary Code Execution https://nvd.nist.gov/vuln/detail/CVE-2021-44832

Upgrade com.jayway.jsonpath:json-path from 2.4.0 to 2.7.0 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2021-27568

The json-path upgrade indirectly upgrades net.minidev:json-smart from 2.3 to 2.4.7 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2021-31684

Upgrade aws-java-sdk from 1.11.163 to 1.12.321 fixing Directory Traversal https://nvd.nist.gov/vuln/detail/CVE-2022-31159

The aws-java-sdk upgrade indirectly upgrades jackson-dataformat-cbor from 2.6.7 to 2.13.4 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2020-28491

Upgrade org.folio:postgres-testing from RMB 33.0.0 to RMB 35.0.1. This indirectly upgrades commons-compress from 1.20 to 1.21 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2021-36090 , https://nvd.nist.gov/vuln/detail/CVE-2021-35515, https://nvd.nist.gov/vuln/detail/CVE-2021-35516, https://nvd.nist.gov/vuln/detail/CVE-2021-35517

In addition upgrade all other pom.xml dependencies to the latest supported version.

Mockito no longer provides the internal class org.mockito.internal.util.reflection.FieldSetter so that the unit tests need to be adjusted accordingly.

## Purpose
Upgrade dependencies fixing vulnerabilities and upgrading from unsupported versions to supported versions.

## Approach
Upgrade dependencies by bumping the version number in the pom.xml file.

## Learning
For each flower release all dependencies should be checked against https://mvnrepository.com/ to find the version to upgrade to.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.