### PR TITLE
MDEXP-566 - Reenabling module fails when reference data already exists

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantReferenceAPI.java
@@ -57,7 +57,7 @@ public class TenantReferenceAPI extends TenantAPI {
   private void buildDataLoadingParameters(TenantAttributes tenantAttributes, TenantLoading tl) {
     if (isLoadReference(tenantAttributes)) {
       tl.withKey(PARAMETER_LOAD_REFERENCE).withLead("data")
-        .withPostOnly()
+        .withPostIgnore()
         .add("mapping-profiles", "data-export/mapping-profiles")
         .add("job-profiles", "data-export/job-profiles");
     }


### PR DESCRIPTION
[MDEXP-566](https://issues.folio.org/browse/MDEXP-566) - Reenabling module fails when reference data already exists

## Purpose
While reenabling mod-data-export-4.5.1 with loadReference=true flag during the upgrade to MorningGlory, it fails with 500 error when using an API call

## Approach
* Fixed TenantReferenceAPI logic

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
