### PR TITLE
MDEXP-636 - Add missing electronic access relationship values to default mapping rules

### DIFF
--- a/src/main/resources/rules/rulesDefault.json
+++ b/src/main/resources/rules/rulesDefault.json
@@ -1934,9 +1934,13 @@
         "translation": {
           "function": "set_electronic_access_indicator",
           "parameters": {
+            "No information provided": " ",
             "Resource": "0",
             "Version of resource": "1",
-            "Related resource": "2"
+            "Related resource": "2",
+            "Component part(s) of resource": "3",
+            "Version of component part(s) of resource": "4",
+            "No display constant generated": "8"
           }
         }
       }


### PR DESCRIPTION
[MDEXP-636](https://issues.folio.org/browse/MDEXP-636) - Add missing electronic access relationship values to default mapping rules

## Purpose
The electronic access relationship values should be added to default mapping rules:
"No information provided": " ",
"Related resource": "2",
"Component part(s) of resource": "3",
"Version of component part(s) of resource": "4",
"No display constant generated": "8"

## Approach
Added values

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
