### PR TITLE
MDEXP-639 - Add "userId" field to "runBy" schema

### DIFF
--- a/ramls/schemas/jobExecution.json
+++ b/ramls/schemas/jobExecution.json
@@ -86,6 +86,10 @@
         "lastName": {
           "description": "Last name",
           "type": "string"
+        },
+        "userId": {
+          "description": "User ID",
+          "$ref": "../../ramls/raml-util/schemas/uuid.schema"
         }
       }
     },

--- a/src/main/java/org/folio/service/job/JobExecutionServiceImpl.java
+++ b/src/main/java/org/folio/service/job/JobExecutionServiceImpl.java
@@ -143,7 +143,8 @@ public class JobExecutionServiceImpl implements JobExecutionService {
     JsonObject personal = user.getJsonObject("personal");
     jobExecution.setRunBy(new RunBy()
       .withFirstName(personal.getString("firstName"))
-      .withLastName(personal.getString("lastName")));
+      .withLastName(personal.getString("lastName"))
+      .withUserId(user.getString("id")));
     if (withProgress) {
       jobExecution.setProgress(new Progress().withTotal(totalCount));
     }

--- a/src/test/java/org/folio/rest/impl/DataExportTest.java
+++ b/src/test/java/org/folio/rest/impl/DataExportTest.java
@@ -601,6 +601,7 @@ class DataExportTest extends RestVerticleTestBase {
               assertEquals(FAIL, jobExecution.getStatus());
               assertNotNull(jobExecution.getCompletedDate());
               assertNotNull(jobExecution.getRunBy());
+              assertNotNull(jobExecution.getRunBy().getUserId());
               assertEquals(1, errorLogs.getErrorLogs().size());
               ErrorLog errorLog = errorLogs.getErrorLogs().get(0);
               assertEquals(ErrorCode.INVALID_UPLOADED_FILE_EXTENSION_FOR_HOLDING_ID_TYPE.getCode(), errorLog.getErrorMessageCode());
@@ -834,6 +835,7 @@ class DataExportTest extends RestVerticleTestBase {
     assertEquals(numberOfExportedRecords, jobExecution.getProgress().getExported());
     assertNotNull(jobExecution.getExportedFiles().iterator().next().getFileName());
     assertNotNull(jobExecution.getRunBy());
+    assertNotNull(jobExecution.getRunBy().getUserId());
     assertNotNull(jobExecution.getJobProfileName());
   }
 

--- a/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
+++ b/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
@@ -67,6 +67,8 @@ class JobExecutionServiceUnitTest {
   private static final String FIRST_NAME_VALUE = "firstName";
   private static final String LAST_NAME_KEY = "lastName";
   private static final String LAST_NAME_VALUE = "lastName";
+  private static final String ID_KEY = "id";
+  private static final String ID_VALUE = UUID.randomUUID().toString();
   private static final int TOTAL_COUNT = 2;
 
   @Spy
@@ -256,7 +258,8 @@ class JobExecutionServiceUnitTest {
     JsonObject user = new JsonObject()
       .put(PERSONAL_KEY, new JsonObject()
         .put(FIRST_NAME_KEY, FIRST_NAME_VALUE)
-        .put(LAST_NAME_KEY, LAST_NAME_VALUE));
+        .put(LAST_NAME_KEY, LAST_NAME_VALUE))
+        .put(ID_KEY, ID_VALUE);
     JobProfile jobProfile = new JobProfile()
       .withId(JOB_PROFILE_ID)
       .withName(JOB_PROFILE_NAME);
@@ -278,6 +281,8 @@ class JobExecutionServiceUnitTest {
           .getFirstName());
         assertEquals(LAST_NAME_VALUE, updatedJobExecution.getRunBy()
           .getLastName());
+        assertEquals(ID_VALUE, updatedJobExecution.getRunBy()
+            .getUserId());
         assertEquals(TOTAL_COUNT, updatedJobExecution.getProgress()
           .getTotal().intValue());
         assertEquals(JOB_PROFILE_NAME, jobExecution.getJobProfileName());


### PR DESCRIPTION
[MDEXP-639](https://issues.folio.org/browse/MDEXP-639) - Add "userId" field to "runBy" schema

## Purpose
runBy should have userId field for filtering purposes.

## Approach
Change schema, add userId to runBy.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
