### PR TITLE
MDEXP-109 - Return list of the job profiles used in completed jobs

### DIFF
--- a/ramls/dataExport-job-profile.raml
+++ b/ramls/dataExport-job-profile.raml
@@ -43,6 +43,12 @@ traits:
       is: [validate]
     get:
       is: [ pageable, searchable: { description: "with valid searchable fields", example: "status=SUCCESS"}, validate ]
+      queryParameters:
+            used:
+              description: true if need already used profiles
+              type: boolean
+              required: false
+              default: false
     /{id}:
       uriParameters:
         id:

--- a/src/main/java/org/folio/dao/JobProfileDao.java
+++ b/src/main/java/org/folio/dao/JobProfileDao.java
@@ -3,6 +3,8 @@ package org.folio.dao;
 import io.vertx.core.Future;
 
 import java.util.Optional;
+
+import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobProfile;
 import org.folio.rest.jaxrs.model.JobProfileCollection;
 
@@ -56,4 +58,14 @@ public interface JobProfileDao {
    * @return future with true is succeeded
    */
   Future<Boolean> deleteById(String id, String tenantId);
+
+  /**
+   * Gets only used job profiles.
+   *
+   * @param offset starting index in a list of records
+   * @param limit maximum number of records to return
+   * @param tenantId tenant id
+   * @return future with {@link JobProfileCollection}
+   */
+  Future<JobProfileCollection> getUsed(int offset, int limit, String tenantId);
 }

--- a/src/main/java/org/folio/dao/impl/JobProfileDaoImpl.java
+++ b/src/main/java/org/folio/dao/impl/JobProfileDaoImpl.java
@@ -110,15 +110,14 @@ public class JobProfileDaoImpl implements JobProfileDao {
   @Override
   public Future<JobProfileCollection> getUsed(int offset, int limit, String tenantId) {
     return pgClientFactory.getInstance(tenantId)
-        .execute(format("SELECT DISTINCT jobProfileId, jsonb ->> 'jobProfileName' FROM %s_mod_data_export.%s OFFSET %s LIMIT %s;",
-            tenantId, JOB_EXECUTIONS_TABLE, offset, limit))
-        .map(results -> {
-          List<JobProfile> list = new ArrayList<>();
-          for (var row: results) {
-            list.add(new JobProfile().withName(row.getString(1)).withId(row.getUUID(0).toString()));
-          }
-          return new JobProfileCollection().withJobProfiles(list);
-        });
+      .execute(format("SELECT DISTINCT jobProfileId, jsonb ->> 'jobProfileName' FROM %s_mod_data_export.%s OFFSET %s LIMIT %s;",
+        tenantId, JOB_EXECUTIONS_TABLE, offset, limit))
+      .map(rows -> {
+        List<JobProfile> jobProfileList = new ArrayList<>();
+        rows.forEach(row -> jobProfileList.add(new JobProfile().withName(row.getString(1)).withId(row.getUUID(0).toString())));
+        return jobProfileList;
+      })
+      .map(jobProfileList -> new JobProfileCollection().withJobProfiles(jobProfileList));
   }
 
 }

--- a/src/main/java/org/folio/dao/impl/JobProfileDaoImpl.java
+++ b/src/main/java/org/folio/dao/impl/JobProfileDaoImpl.java
@@ -117,7 +117,7 @@ public class JobProfileDaoImpl implements JobProfileDao {
         rows.forEach(row -> jobProfileList.add(new JobProfile().withName(row.getString(1)).withId(row.getUUID(0).toString())));
         return jobProfileList;
       })
-      .map(jobProfileList -> new JobProfileCollection().withJobProfiles(jobProfileList));
+      .map(jobProfileList -> new JobProfileCollection().withJobProfiles(jobProfileList).withTotalRecords(jobProfileList.size()));
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/DataExportImplJobProfileImpl.java
+++ b/src/main/java/org/folio/rest/impl/DataExportImplJobProfileImpl.java
@@ -5,11 +5,13 @@ import static java.lang.String.format;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileCollection;
 import org.folio.rest.jaxrs.resource.DataExportJobProfiles;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.service.profiles.jobprofile.JobProfileService;
@@ -79,13 +81,19 @@ public class DataExportImplJobProfileImpl implements DataExportJobProfiles {
   }
 
   @Override
-  public void getDataExportJobProfiles(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    succeededFuture().compose(ar -> jobProfileService.get(query, offset, limit, tenantId))
-      .map(GetDataExportJobProfilesResponse::respond200WithApplicationJson)
-      .map(Response.class::cast)
-      .otherwise(ExceptionToResponseMapper::map)
-      .onComplete(asyncResultHandler);
+  public void getDataExportJobProfiles(boolean used, int offset, int limit, String query, String lang,
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    succeededFuture().compose(ar -> get(used, offset, limit, query))
+        .map(GetDataExportJobProfilesResponse::respond200WithApplicationJson)
+        .map(Response.class::cast)
+        .otherwise(ExceptionToResponseMapper::map)
+        .onComplete(asyncResultHandler);
+  }
 
+  private Future<JobProfileCollection> get(boolean used, int offset, int limit, String query) {
+    if (used) {
+      return jobProfileService.getUsed(offset, limit, tenantId);
+    }
+    return jobProfileService.get(query, offset, limit, tenantId);
   }
 }

--- a/src/main/java/org/folio/service/profiles/jobprofile/JobProfileService.java
+++ b/src/main/java/org/folio/service/profiles/jobprofile/JobProfileService.java
@@ -61,4 +61,13 @@ public interface JobProfileService {
    */
   Future<Boolean> deleteById(String id, String tenantId);
 
+  /**
+   * Searches for only used {@link JobProfile}
+   *
+   * @param offset starting index in a list of records
+   * @param limit maximum number of records to return
+   * @param tenantId tenant id
+   * @return future with {@link JobProfileCollection}
+   */
+  Future<JobProfileCollection> getUsed(int offset, int limit, String tenantId);
 }

--- a/src/main/java/org/folio/service/profiles/jobprofile/JobProfileServiceImpl.java
+++ b/src/main/java/org/folio/service/profiles/jobprofile/JobProfileServiceImpl.java
@@ -117,4 +117,9 @@ public class JobProfileServiceImpl implements JobProfileService {
     return jobProfileDao.deleteById(id, tenantId);
   }
 
+  @Override
+  public Future<JobProfileCollection> getUsed(int offset, int limit, String tenantId) {
+    return jobProfileDao.getUsed(offset, limit, tenantId);
+  }
+
 }

--- a/src/test/java/org/folio/service/profiles/JobProfileServiceUnitTest.java
+++ b/src/test/java/org/folio/service/profiles/JobProfileServiceUnitTest.java
@@ -26,6 +26,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.NotFoundException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,6 +34,7 @@ import java.util.UUID;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Collections.singletonList;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -190,6 +192,24 @@ class JobProfileServiceUnitTest {
     future.onComplete(ar -> context.verify(() -> {
       assertTrue(ar.succeeded());
       verify(jobProfileDao).get(eq(query), eq(0), eq(10), eq(TENANT_ID));
+      context.completeNow();
+    }));
+  }
+
+  @Test
+  void getUsed_shouldReturnUsedJobProfiles(VertxTestContext context) {
+    // given
+    when(jobProfileDao.getUsed(0, 10, TENANT_ID)).thenReturn(Future.succeededFuture(new JobProfileCollection()
+      .withJobProfiles(List.of(new JobProfile().withName("test").withId(UUID.randomUUID().toString())))
+      .withTotalRecords(1)));
+    // when
+    Future<JobProfileCollection> future = jobProfileService.getUsed(0, 10, TENANT_ID);
+    // then
+    future.onComplete(ar -> context.verify(() -> {
+      assertTrue(ar.succeeded());
+      assertEquals(1, ar.result().getJobProfiles().size());
+      assertEquals(1, ar.result().getTotalRecords());
+      assertEquals("test", ar.result().getJobProfiles().get(0).getName());
       context.completeNow();
     }));
   }


### PR DESCRIPTION
[MDEXP-109](https://issues.folio.org/browse/MDEXP-109) - Return list of the job profiles used in completed jobs

## Purpose
In the UI user will be able to filter completed export jobs by job profiles that were used in already completed jobs. In order to do so the UI will need to have a list of the job profiles to populate UI dropdown.

## Approach
Select distinct job profiles from job executions.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
