### PR TITLE
MDEXP-668 - Regression: Failed jobs listed always on top of the queue when completeDate is missing

### DIFF
--- a/src/main/java/org/folio/dao/JobExecutionDao.java
+++ b/src/main/java/org/folio/dao/JobExecutionDao.java
@@ -68,4 +68,12 @@ public interface JobExecutionDao {
    */
   Future<List<JobExecution>> getExpiredEntries(Date lastUpdateDate, String tenantId);
 
+  /**
+   * Fetch list of failed {@link JobExecution} without completed date from database
+   *
+   * @param tenantId       tenant id
+   * @return future with list of expire {@link JobExecution}
+   */
+  Future<List<JobExecution>> getFailedEntriesWithoutCompletedDate(String tenantId);
+
 }

--- a/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
+++ b/src/main/java/org/folio/service/file/upload/FileUploadServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.service.file.upload;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.folio.HttpStatus;
@@ -189,7 +190,7 @@ public class FileUploadServiceImpl implements FileUploadService {
         jobExecutionService.prepareAndSaveJobForFailedExport(jobExecution, fileDefinition, optionalUser.get(), 0, true, params.getTenantId());
       } else {
         errorLogService.saveGeneralError(ErrorCode.USER_NOT_FOUND.getDescription() + " with id: " + request.getMetadata().getCreatedByUserId(), jobExecution.getId(), params.getTenantId());
-        jobExecutionService.update(jobExecution.withStatus(JobExecution.Status.FAIL), params.getTenantId());
+        jobExecutionService.update(jobExecution.withStatus(JobExecution.Status.FAIL).withCompletedDate(new Date()), params.getTenantId());
       }
     }
     failFileDefinition(promise, fileDefinition, params.getTenantId(), cause);

--- a/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
+++ b/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
@@ -321,9 +321,9 @@ class JobExecutionServiceUnitTest {
         assertTrue(ar.succeeded());
         assertNotNull(jobExecution.getCompletedDate());
         assertNotNull(secondJobExecution.getCompletedDate());
-        verify(jobExecutionDao).update(jobExecution.withStatus(FAIL), eq(TENANT_ID));
-        verify(jobExecutionDao).update(secondJobExecution.withStatus(FAIL), eq(TENANT_ID));
-        verify(jobExecutionDao).update(failedJobExecution.withCompletedDate(failedJobExecutionLastUpdatedDate), eq(TENANT_ID));
+        verify(jobExecutionDao).update(jobExecution.withStatus(FAIL), TENANT_ID);
+        verify(jobExecutionDao).update(secondJobExecution.withStatus(FAIL), TENANT_ID);
+        verify(jobExecutionDao).update(failedJobExecution.withCompletedDate(failedJobExecutionLastUpdatedDate), TENANT_ID);
         context.completeNow();
       })
     );

--- a/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
+++ b/src/test/java/org/folio/service/job/JobExecutionServiceUnitTest.java
@@ -17,7 +17,6 @@ import org.folio.rest.jaxrs.model.FileDefinition;
 import org.folio.rest.jaxrs.model.JobExecution;
 import org.folio.rest.jaxrs.model.JobExecutionCollection;
 import org.folio.rest.jaxrs.model.JobProfile;
-import org.folio.rest.jaxrs.model.JobProfileCollection;
 import org.folio.rest.jaxrs.model.Progress;
 import org.folio.service.export.storage.ExportStorageService;
 import org.folio.service.logs.ErrorLogService;
@@ -31,12 +30,12 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.folio.rest.jaxrs.model.JobExecution.Status.FAIL;
 import static org.folio.rest.jaxrs.model.JobExecution.Status.IN_PROGRESS;
 import static org.folio.rest.jaxrs.model.JobExecution.Status.NEW;
@@ -305,7 +304,14 @@ class JobExecutionServiceUnitTest {
       .withExportedFiles(Sets.newHashSet())
       .withJobProfileId(JOB_PROFILE_ID)
       .withStatus(NEW);
+    var failedJobExecutionId = UUID.randomUUID().toString();
+    var failedJobExecutionLastUpdatedDate = new Date();
+    JobExecution failedJobExecution = new JobExecution()
+      .withId(failedJobExecutionId)
+      .withLastUpdatedDate(failedJobExecutionLastUpdatedDate)
+      .withStatus(FAIL);
     when(jobExecutionDao.getExpiredEntries(any(Date.class), eq(TENANT_ID))).thenReturn(Future.succeededFuture(asList(jobExecution, secondJobExecution)));
+    when(jobExecutionDao.getFailedEntriesWithoutCompletedDate(TENANT_ID)).thenReturn(Future.succeededFuture(Collections.singletonList(failedJobExecution)));
 
     // when
     Future<Void> future = jobExecutionService.expireJobExecutions(TENANT_ID);
@@ -315,8 +321,9 @@ class JobExecutionServiceUnitTest {
         assertTrue(ar.succeeded());
         assertNotNull(jobExecution.getCompletedDate());
         assertNotNull(secondJobExecution.getCompletedDate());
-        verify(jobExecutionDao).update(eq(jobExecution.withStatus(FAIL)), eq(TENANT_ID));
-        verify(jobExecutionDao).update(eq(secondJobExecution.withStatus(FAIL)), eq(TENANT_ID));
+        verify(jobExecutionDao).update(jobExecution.withStatus(FAIL), eq(TENANT_ID));
+        verify(jobExecutionDao).update(secondJobExecution.withStatus(FAIL), eq(TENANT_ID));
+        verify(jobExecutionDao).update(failedJobExecution.withCompletedDate(failedJobExecutionLastUpdatedDate), eq(TENANT_ID));
         context.completeNow();
       })
     );


### PR DESCRIPTION
[MDEXP-668](https://issues.folio.org/browse/MDEXP-668) - Regression: Failed jobs listed always on top of the queue when completeDate is missing

## Purpose
In some cases when the job finishes with status Failed the completedDate is not populated.  This happens when the job fails due to connectivity issue  for example and the job stays on top of the queue, and the provided Ended Running date is always set to the current date even if the export occurred in the past.   Here is the example from the bugfest environment.

## Approach
* Improved logic to set job execution completed date
* Updated logic to set completed date if it was not set to failed job executions upon expiring job execution API call
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
