### PR TITLE
MDEXP-652 - "Linking ISSN" (022$l) and "Invalid ISBN" (020$z) missed for  MARC bib records generated on the fly

### DIFF
--- a/src/main/resources/rules/rulesDefault.json
+++ b/src/main/resources/rules/rulesDefault.json
@@ -141,7 +141,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "a",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "ISBN"
           }
@@ -151,7 +151,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "z",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "Invalid ISBN"
           }
@@ -189,7 +189,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "a",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "ISSN"
           }
@@ -199,7 +199,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "l",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "Linking ISSN"
           }
@@ -209,7 +209,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "z",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "Invalid ISSN"
           }
@@ -1041,7 +1041,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "a",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "GPO item number"
           }
@@ -1051,7 +1051,7 @@
         "from": "$.instance.identifiers[*].value",
         "subfield": "z",
         "translation": {
-          "function": "append_identifier",
+          "function": "set_or_append_identifier",
           "parameters": {
             "type": "Cancelled GPO item number"
           }


### PR DESCRIPTION
[MDEXP-652](https://issues.folio.org/browse/MDEXP-652) - "Linking ISSN" (022$l) and "Invalid ISBN" (020$z) missed for  MARC bib records generated on the fly

## Purpose
For the MARC bib records generated on the fly, the Instances identifiers  should be set the following way: "Linking ISSN" set to 022 \ \ $l and "Invalid ISBN" set to 020 \ \ $z 
UPD: also reproduced for :
"Invalid ISSN" 022 \ \ $z without  "ISSN"{}{}
"Cancelled GPO Item number" 074 \ \ $z without "GPO Item number" 074 \ \ $a
But these identifiers are missed in .mrc file in case Instance has no  ISSN (022$a) or  ISBN (020$a)
The issue is reproduced only for MARC bib records generated on the fly

## Approach
Updated default rules to use new function

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
