### PR TITLE
MDEXP-743 - Unhandled error when id is missing in POST /file-definition request's payload

### DIFF
--- a/src/main/java/org/folio/dataexp/service/FileDefinitionsService.java
+++ b/src/main/java/org/folio/dataexp/service/FileDefinitionsService.java
@@ -1,5 +1,7 @@
 package org.folio.dataexp.service;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.dataexp.domain.dto.FileDefinition;
@@ -29,6 +31,9 @@ public class FileDefinitionsService {
   private final FolioExecutionContext folioExecutionContext;
 
   public FileDefinition postFileDefinition(FileDefinition fileDefinition) {
+    if (isEmpty(fileDefinition.getId())) {
+      fileDefinition.setId(UUID.randomUUID());
+    }
     log.info("Post file definition by id {}", fileDefinition.getId());
     fileDefinitionValidator.validate(fileDefinition);
     var jobExecution = jobExecutionService.save(new JobExecution().status(JobExecution.StatusEnum.NEW));

--- a/src/test/java/org/folio/dataexp/service/FileDefinitionsServiceTest.java
+++ b/src/test/java/org/folio/dataexp/service/FileDefinitionsServiceTest.java
@@ -49,7 +49,6 @@ class FileDefinitionsServiceTest {
   @Test
   void postFileDefinitionTest() {
     var fileDefinition = new FileDefinition();
-    fileDefinition.setId(UUID.randomUUID());
     fileDefinition.fileName("upload.csv");
 
     var fileDefinitionEntity = FileDefinitionEntity.builder().fileDefinition(fileDefinition).build();
@@ -59,6 +58,7 @@ class FileDefinitionsServiceTest {
     when(folioExecutionContext.getUserId()).thenReturn(UUID.randomUUID());
 
     var savedFileDefinition = fileDefinitionsService.postFileDefinition(fileDefinition);
+    assertNotNull(savedFileDefinition.getId());
     assertEquals(FileDefinition.StatusEnum.NEW, savedFileDefinition.getStatus());
     assertNotNull(savedFileDefinition.getJobExecutionId());
 


### PR DESCRIPTION
[MDEXP-743](https://folio-org.atlassian.net/browse/MDEXP-743) - Unhandled error when id is missing in POST /file-definition request's payload

## Purpose
In prior releases POST to https://folio-snapshot-okapi.dev.folio.org/data-export/file-definitions did not require an id in the payload, now a HTTP 500 error is returned if Id is not passed in.

## Approach
* Fixed fileDefinitionService logic
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
