### PR TITLE
MDEXP-739 - mod-data-export documentation updating

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.REF }}
           submodules: recursive

--- a/src/main/java/org/folio/dataexp/controllers/DataExportController.java
+++ b/src/main/java/org/folio/dataexp/controllers/DataExportController.java
@@ -22,6 +22,6 @@ public class DataExportController implements  ExportApi {
   @Override
   public ResponseEntity<Void> postDataExport(ExportRequest exportRequest) {
     dataExportService.postDataExport(exportRequest);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
   }
 }

--- a/src/main/resources/swagger.api/data-export.yaml
+++ b/src/main/resources/swagger.api/data-export.yaml
@@ -964,3 +964,4 @@ components:
       schema:
         default: false
         type: boolean
+

--- a/src/test/java/org/folio/dataexp/controllers/DataExportControllerTest.java
+++ b/src/test/java/org/folio/dataexp/controllers/DataExportControllerTest.java
@@ -31,7 +31,7 @@ class DataExportControllerTest extends BaseDataExportInitializer {
         .post("/data-export/export")
         .headers(defaultHeaders())
         .content(asJsonString(exportRequest)))
-      .andExpect(status().isOk());
+      .andExpect(status().isNoContent());
 
     verify(dataExportService).postDataExport(isA(ExportRequest.class));
   }


### PR DESCRIPTION
[MDEXP-739](https://folio-org.atlassian.net/browse/MDEXP-739) - mod-data-export documentation updating

## Purpose
Documentation FOLIO Developers | Reference |  API documentation  still points to the ramls directory despite the fact mod-data-export was refactored to use spring-base and swagger. As a result API documentation is invalid. Also, in some cases there was a change in the contract and those changes will need to be documented in the Release notes so that the libraries that script their data export can adjust their scripts accordingly.

## Approach
* Fixed settings and controller
* Updated unit tests

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
