### PR TITLE
MDEXP-753 - Automate manual marking default authorities profiles as default

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -13,4 +13,5 @@
     <include file="changes/job_executions_exports_ids_unique_constraint.xml" relativeToChangelogFile="true"/>
     <include file="changes/add_generation.xml" relativeToChangelogFile="true"/>
     <include file="changes/audit_instance_view.xml" relativeToChangelogFile="true"/>
+    <include file="changes/update_default_authority_profiles.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/update_default_authority_profiles.sql
+++ b/src/main/resources/db/changelog/changes/update_default_authority_profiles.sql
@@ -1,0 +1,7 @@
+UPDATE ${myuniversity}_mod_data_export.job_profiles
+	SET jsonb = jsonb || '{"default": true}'
+	WHERE id = '56944b1c-f3f9-475b-bed0-7387c33620ce' OR id = '2c9be114-6d35-4408-adac-9ead35f51a27';
+
+UPDATE ${myuniversity}_mod_data_export.mapping_profiles
+	SET jsonb = jsonb || '{"default": true}'
+	WHERE id = '5d636597-a59d-4391-a270-4e79d5ba70e3';

--- a/src/main/resources/db/changelog/changes/update_default_authority_profiles.xml
+++ b/src/main/resources/db/changelog/changes/update_default_authority_profiles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+
+  <changeSet id="update_default_authority_profiles" author="Firebird">
+    <sqlFile path="update_default_authority_profiles.sql" relativeToChangelogFile="true" />
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
[MDEXP-753](https://folio-org.atlassian.net/browse/MDEXP-753) - Automate manual marking default authorities profiles as default

## Purpose
The “Required manual migration” instructions require sysops to manually search for the default authorities profile and to manually mark it as default.

## Approach
Write migration script to set all default profiles to 'true'.

#### TODOS and Open Questions

## Learning

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
