### PR TITLE
MDEXP-752: Automate manual deletion of error_logs where jobExecutionId=''

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -9,6 +9,7 @@
     <include file="changes/add_config.xml" relativeToChangelogFile="true"/>
     <include file="changes/add_export_all.xml" relativeToChangelogFile="true"/>
     <include file="changes/slice_records_all_ids.xml" relativeToChangelogFile="true"/>
+    <include file="changes/delete_error_logs_empty_job_execution_id.xml" relativeToChangelogFile="true"/>
     <include file="changes/enrich_tables.xml" relativeToChangelogFile="true"/>
     <include file="changes/job_executions_exports_ids_unique_constraint.xml" relativeToChangelogFile="true"/>
     <include file="changes/add_generation.xml" relativeToChangelogFile="true"/>

--- a/src/main/resources/db/changelog/changes/delete_error_logs_empty_job_execution_id.sql
+++ b/src/main/resources/db/changelog/changes/delete_error_logs_empty_job_execution_id.sql
@@ -1,0 +1,2 @@
+-- enrich_tables.sql fails when trying to convert '' to UUID
+DELETE FROM error_logs WHERE jsonb ->> 'jobExecutionId' = '';

--- a/src/main/resources/db/changelog/changes/delete_error_logs_empty_job_execution_id.xml
+++ b/src/main/resources/db/changelog/changes/delete_error_logs_empty_job_execution_id.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="delete_error_logs_empty_job_execution_id" author="julianladisch">
+    <sqlFile dbms="postgresql"
+             path="delete_error_logs_empty_job_execution_id.sql"
+             relativeToChangelogFile="true"
+             splitStatements="false"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/enrich_tables.sql
+++ b/src/main/resources/db/changelog/changes/enrich_tables.sql
@@ -131,6 +131,8 @@ $$
 $$;
 
 -- error_logs
+DELETE FROM error_logs WHERE jsonb ->> 'jobExecutionId' = '';
+
 ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS job_execution_id uuid;
 
 do

--- a/src/main/resources/db/changelog/changes/enrich_tables.sql
+++ b/src/main/resources/db/changelog/changes/enrich_tables.sql
@@ -131,8 +131,6 @@ $$
 $$;
 
 -- error_logs
-DELETE FROM error_logs WHERE jsonb ->> 'jobExecutionId' = '';
-
 ALTER TABLE error_logs ADD COLUMN IF NOT EXISTS job_execution_id uuid;
 
 do


### PR DESCRIPTION
[MDEXP-752](https://folio-org.atlassian.net/browse/MDEXP-752) - Automate manual deletion of error_logs where `jsonb ->> 'jobExecutionId' = ''`

## Purpose
The “Required manual migration” instructions require sysops to manually delete records in error_logs where 'jobExecutionId' = ''. Those records must be deleted, otherwise enrich_tables.sql fails the migration when trying to convert the '' into UUID. This should be automated to reduce the number of manual tasks and to make the migration less error-prone.

## Approach
Add the DELETE SQL statement to a new delete_error_logs_empty_job_execution_id.sql that runs before enrich_tables.sql.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.