### PR TITLE
MDEXP-748 - Export all - Handle error details of bad data records 

### DIFF
--- a/src/main/java/org/folio/dataexp/util/ErrorCode.java
+++ b/src/main/java/org/folio/dataexp/util/ErrorCode.java
@@ -66,7 +66,8 @@ public enum ErrorCode {
   ERROR_CONVERTING_TO_JSON_HOLDING("error.convertingToJson.holding", "Error converting to json holding by id %s"),
   ERROR_CONVERTING_TO_JSON_INSTANCE("error.convertingToJson.instance", "Error converting to json instance by id %s"),
   ERROR_DELETED_DUPLICATED_INSTANCE("error.deletedDuplicate.instance", "Instance record associated with %s has been deleted."),
-  ERROR_DELETED_TOO_LONG_INSTANCE("error.deletedTooLong.instance", "Instance record with id = %s has been deleted.");
+  ERROR_DELETED_TOO_LONG_INSTANCE("error.deletedTooLong.instance", "Instance record with id = %s has been deleted."),
+  ERROR_NON_EXISTING_INSTANCE("error.nonExisting.instance", "%s");
 
   private final String code;
   private final String description;

--- a/src/test/java/org/folio/dataexp/service/export/strategies/AbstractExportStrategyTest.java
+++ b/src/test/java/org/folio/dataexp/service/export/strategies/AbstractExportStrategyTest.java
@@ -1,6 +1,7 @@
 package org.folio.dataexp.service.export.strategies;
 
 import lombok.Setter;
+import org.folio.dataexp.domain.dto.ErrorLog;
 import org.folio.dataexp.domain.dto.ExportRequest;
 import org.folio.dataexp.domain.dto.JobExecution;
 import org.folio.dataexp.domain.dto.JobExecutionProgress;
@@ -14,6 +15,7 @@ import org.folio.dataexp.domain.entity.MappingProfileEntity;
 import org.folio.dataexp.domain.entity.MarcRecordEntity;
 import org.folio.dataexp.exception.export.LocalStorageWriterException;
 import org.folio.dataexp.repository.ExportIdEntityRepository;
+import org.folio.dataexp.repository.InstanceEntityRepository;
 import org.folio.dataexp.repository.JobExecutionEntityRepository;
 import org.folio.dataexp.repository.JobExecutionExportFilesEntityRepository;
 import org.folio.dataexp.repository.JobProfileEntityRepository;
@@ -21,6 +23,7 @@ import org.folio.dataexp.repository.MappingProfileEntityRepository;
 import org.folio.dataexp.service.JobExecutionService;
 import org.folio.dataexp.service.export.LocalStorageWriter;
 import org.folio.dataexp.service.logs.ErrorLogService;
+import org.folio.dataexp.util.ErrorCode;
 import org.folio.s3.client.FolioS3Client;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +62,8 @@ class AbstractExportStrategyTest {
   private JobExecutionExportFilesEntityRepository jobExecutionExportFilesEntityRepository;
   @Mock
   private ExportIdEntityRepository exportIdEntityRepository;
+  @Mock
+  private InstanceEntityRepository instanceEntityRepository;
   @Mock
   private MappingProfileEntityRepository mappingProfileEntityRepository;
   @Mock
@@ -129,6 +134,11 @@ class AbstractExportStrategyTest {
 
     assertEquals(JobExecutionExportFilesStatus.ACTIVE, exportFilesEntity.getStatus());
 
+
+    verify(errorLogService, times(1))
+      .saveGeneralErrorWithMessageValues(eq(ErrorCode.ERROR_NON_EXISTING_INSTANCE.getCode()), eq(List.of(marcRecordEntity.getId().toString())), eq(jobExecution.getId()));
+    verify(errorLogService, times(1))
+      .saveGeneralErrorWithMessageValues(eq(ErrorCode.ERROR_DUPLICATE_SRS_RECORD.getCode()), isA(List.class), eq(jobExecution.getId()));
     verify(jobExecutionEntityRepository, times(2)).save(isA(JobExecutionEntity.class));
     verify(localStorageWriter, times(2)).write(isA(String.class));
   }


### PR DESCRIPTION
[MDEXP-748](https://folio-org.atlassian.net/browse/MDEXP-748)

## Purpose
Adding log entry for SRS records duplication in case externalId is absent in database.

## Approach
Adding logging for handling error.

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] Check logging
  - [ ] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
