### PR TITLE
MDEXP-793 - Export all - Set LDR05 to "d" for records set for deletion

### DIFF
--- a/src/main/java/org/folio/dataexp/repository/FolioInstanceAllRepository.java
+++ b/src/main/java/org/folio/dataexp/repository/FolioInstanceAllRepository.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.UUID;
 
 public interface FolioInstanceAllRepository extends Repository<InstanceEntity, UUID> {
+  // all instances, including set for deletion
+  @Query(value = "SELECT * FROM v_folio_instance_all WHERE id BETWEEN ?1 AND ?2 ORDER BY id ASC", nativeQuery = true)
+  Slice<InstanceEntity> findFolioInstanceAll(UUID fromId, UUID toId, Pageable page);
 
   // onlyNonDeleted, suppressedFromDiscovery = true
   @Query(value = "SELECT * FROM v_folio_instance_all_non_deleted WHERE id BETWEEN ?1 AND ?2 ORDER BY id ASC", nativeQuery = true)

--- a/src/main/java/org/folio/dataexp/service/export/strategies/InstancesExportAllStrategy.java
+++ b/src/main/java/org/folio/dataexp/service/export/strategies/InstancesExportAllStrategy.java
@@ -208,7 +208,10 @@ public class InstancesExportAllStrategy extends InstancesExportStrategy {
   }
 
   private Slice<InstanceEntity> nextFolioSlice(JobExecutionExportFilesEntity exportFilesEntity, ExportRequest exportRequest, Pageable pageble) {
-    if (Boolean.TRUE.equals(exportRequest.getSuppressedFromDiscovery())) {
+    if (Boolean.TRUE.equals(exportRequest.getDeletedRecords())) {
+      return folioInstanceAllRepository.findFolioInstanceAll(exportFilesEntity.getFromId(), exportFilesEntity.getToId(),
+        pageble);
+    } else if (Boolean.TRUE.equals(exportRequest.getSuppressedFromDiscovery())) {
       return folioInstanceAllRepository.findFolioInstanceAllNonDeleted(exportFilesEntity.getFromId(), exportFilesEntity.getToId(),
           pageble);
     }

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -17,4 +17,5 @@
     <include file="changes/update_default_authority_profiles.xml" relativeToChangelogFile="true"/>
     <include file="changes/add_default_deleted_authority_job_profile.xml" relativeToChangelogFile="true"/>
     <include file="changes/remove_audit_for_marc.xml" relativeToChangelogFile="true"/>
+    <include file="changes/export_all_set_for_deletion.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/export_all_set_for_deletion.sql
+++ b/src/main/resources/db/changelog/changes/export_all_set_for_deletion.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW ${myuniversity}_mod_data_export.v_folio_instance_all
+AS SELECT inst.id, jsonb FROM ${myuniversity}_mod_data_export.v_instance inst
+   WHERE jsonb ->> 'source' = 'FOLIO';
+
+CREATE OR REPLACE VIEW ${myuniversity}_mod_data_export.v_folio_instance_all_non_deleted
+AS SELECT inst.id, jsonb FROM ${myuniversity}_mod_data_export.v_instance inst
+   WHERE jsonb ->> 'source' = 'FOLIO' AND
+     ((jsonb ->> 'dicscoverySuppress' IS NULL OR jsonb ->> 'discoverySuppress' = 'false') AND
+      (jsonb ->> 'staffSuppress' IS NULL OR jsonb ->> 'staffSuppress' = 'false'));

--- a/src/main/resources/db/changelog/changes/export_all_set_for_deletion.xml
+++ b/src/main/resources/db/changelog/changes/export_all_set_for_deletion.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="export_all_set_for_deletion" author="Firebird">
+        <createProcedure path="export_all_set_for_deletion.sql" relativeToChangelogFile="true" />
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
[MDEXP-793](https://folio-org.atlassian.net/browse/MDEXP-793) - Export all - Set LDR05 to "d" for records set for deletion

## Purpose
When a FOLIO instance is set for deletion and the exported MARC  is generated on the fly, LDR05 should be set to “d” during export all.  The export-all does not take into account FOLIO instances that are deleted through API call so the values stored in instance-audit table can be disregarded for  export-all purposes.

## Approach
* Updated logic

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [ ] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
