### PR TITLE
MODLD-943: set lib-linked-data-rdf4ld version for Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <json-smart.version>2.5.2</json-smart.version>
     <json-path.version>2.9.0</json-path.version>
     <lib-fqm-query-processor.version>4.0.2</lib-fqm-query-processor.version>
-    <lib-linked-data-rdf4ld.version>1.0.0-SNAPSHOT</lib-linked-data-rdf4ld.version>
+    <lib-linked-data-rdf4ld.version>0.9.9</lib-linked-data-rdf4ld.version>
 
     <!-- Test dependencies versions -->
     <testcontainer.version>1.21.4</testcontainer.version>


### PR DESCRIPTION
## Purpose
Since lib-linked-data-rdf4ld has been migrated to Spring Boot 4 (with Jackson 3), it causes a build failure,
Set lib-linked-data-rdf4ld version to 0.9.9 which is latest version based on Spring Boot 3.

Please change it back to 1.0.0-SNAPSHOT once mod-data-export is migrated to Spring Boot 4.