### PR TITLE
MDEXP-921: “Failed“ column is empty when export using Default linked data export job profile completes with errors or fails with not found records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## v5.5.0 Unreleased
 
+
+### Bugs
+[MDEXP-921](https://folio-org.atlassian.net/browse/MDEXP-921) “Failed“ column is empty when export using Default linked data export job profile completes with errors or fails with not found records
+
 ## 04/17/2026 v5.4.0 Released
 
 This release contains LINKED_DATA support and other improvements and bug fixes

--- a/src/main/java/org/folio/dataexp/service/export/strategies/ld/AbstractLinkedDataExportStrategy.java
+++ b/src/main/java/org/folio/dataexp/service/export/strategies/ld/AbstractLinkedDataExportStrategy.java
@@ -217,6 +217,7 @@ public abstract class AbstractLinkedDataExportStrategy extends AbstractExportStr
               .map(UUID::fromString)
               .collect(Collectors.toSet());
       externalIds.removeAll(resultUuids);
+      exportStatistic.setFailed(exportStatistic.getFailed() + externalIds.size());
       exportStatistic.addNotExistIdsAll(externalIds.stream().toList());
     }
   }

--- a/src/test/java/org/folio/dataexp/service/export/strategies/ld/AbstractLinkedDataExportStrategyTest.java
+++ b/src/test/java/org/folio/dataexp/service/export/strategies/ld/AbstractLinkedDataExportStrategyTest.java
@@ -224,7 +224,7 @@ class AbstractLinkedDataExportStrategyTest {
 
     assertEquals(0, exportStatistic.getExported());
     assertEquals(0, exportStatistic.getDuplicatedSrs());
-    assertEquals(0, exportStatistic.getFailed());
+    assertEquals(1, exportStatistic.getFailed());
     assertEquals(List.of(preparation.exportId), exportStatistic.getNotExistIds());
     assertEquals(JobExecutionExportFilesStatus.ACTIVE, preparation.exportFilesEntity.getStatus());
     verify(localStorageWriter, never()).write(isA(String.class));


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MDEXP-921

## Purpose

Correct the failed record count for jobs with invalid IDs.

## Approach

In addition to existing code for saving the not found ID set in export statistics, also update the statistics failure count.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] Check logging
  - [x] There are no major code smells or security issues

- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
